### PR TITLE
프론트엔드 베이스 코드 추가

### DIFF
--- a/client/.eslintrc.json
+++ b/client/.eslintrc.json
@@ -14,6 +14,7 @@
   "rules": {
     "max-len": ["error", 100],
     "quotes": ["error", "single", { "allowTemplateLiterals": true }],
-    "comma-dangle": ["error", "always-multiline"]
+    "comma-dangle": ["error", "always-multiline"],
+    "@typescript-eslint/no-explicit-any": ["off"]
   }
 }

--- a/client/index.scss
+++ b/client/index.scss
@@ -1,3 +1,7 @@
+@import './src/style/global.scss';
+@import './src/style/reset.scss';
+@import './src/style/variable.scss';
+
 div {
   box-sizing: border-box;
 }

--- a/client/index.ts
+++ b/client/index.ts
@@ -16,5 +16,5 @@ const routes = isLoggedIn ? authorizedRoutes : unauthorizedRoutes;
 
 export const router = new Router({ routes, pageState });
 
-const app: HTMLElement = new App();
+const app: HTMLElement = new App({ isLoggedIn });
 root?.append(app);

--- a/client/public/assets/icon/calendarIcon.svg
+++ b/client/public/assets/icon/calendarIcon.svg
@@ -1,0 +1,6 @@
+<svg width="24" height="24" viewBox="0 0 24 24" fill="none" xmlns="http://www.w3.org/2000/svg">
+<path d="M19 4H5C3.89543 4 3 4.89543 3 6V20C3 21.1046 3.89543 22 5 22H19C20.1046 22 21 21.1046 21 20V6C21 4.89543 20.1046 4 19 4Z" stroke="#ffffff" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"/>
+<path d="M16 2V6" stroke="#ffffff" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"/>
+<path d="M8 2V6" stroke="#ffffff" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"/>
+<path d="M3 10H21" stroke="#ffffff" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"/>
+</svg>

--- a/client/public/assets/icon/chartIcon.svg
+++ b/client/public/assets/icon/chartIcon.svg
@@ -1,0 +1,5 @@
+<svg width="24" height="24" viewBox="0 0 24 24" fill="none" xmlns="http://www.w3.org/2000/svg">
+<path d="M18 20V10" stroke="#ffffff" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"/>
+<path d="M12 20V4" stroke="#ffffff" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"/>
+<path d="M6 20V14" stroke="#ffffff" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"/>
+</svg>

--- a/client/public/assets/icon/checkIcon.svg
+++ b/client/public/assets/icon/checkIcon.svg
@@ -1,0 +1,3 @@
+<svg width="20" height="14" viewBox="0 0 20 14" fill="none" xmlns="http://www.w3.org/2000/svg">
+<path d="M19 1L6.625 13L1 7.54545" stroke="#fff" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"/>
+</svg>

--- a/client/public/assets/icon/downArrow.svg
+++ b/client/public/assets/icon/downArrow.svg
@@ -1,0 +1,3 @@
+<svg width="10" height="7" viewBox="0 0 10 7" fill="none" xmlns="http://www.w3.org/2000/svg">
+<path d="M1 1.5L5 5.5L9 1.5" stroke="#8D9393" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"/>
+</svg>

--- a/client/public/assets/icon/historyIcon.svg
+++ b/client/public/assets/icon/historyIcon.svg
@@ -1,0 +1,7 @@
+<svg width="24" height="24" viewBox="0 0 24 24" fill="none" xmlns="http://www.w3.org/2000/svg">
+<path d="M14 2H6C5.46957 2 4.96086 2.21071 4.58579 2.58579C4.21071 2.96086 4 3.46957 4 4V20C4 20.5304 4.21071 21.0391 4.58579 21.4142C4.96086 21.7893 5.46957 22 6 22H18C18.5304 22 19.0391 21.7893 19.4142 21.4142C19.7893 21.0391 20 20.5304 20 20V8L14 2Z" stroke="#fff" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"/>
+<path d="M14 2V8H20" stroke="#fff" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"/>
+<path d="M16 13H8" stroke="#fff" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"/>
+<path d="M16 17H8" stroke="#fff" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"/>
+<path d="M10 9H9H8" stroke="#fff" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"/>
+</svg>

--- a/client/public/assets/icon/leftArrow.svg
+++ b/client/public/assets/icon/leftArrow.svg
@@ -1,0 +1,3 @@
+<svg width="24" height="24" viewBox="0 0 24 24" fill="none" xmlns="http://www.w3.org/2000/svg">
+<path d="M16 20L8 12L16 4" stroke="#FCFCFC" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"/>
+</svg>

--- a/client/public/assets/icon/picker.svg
+++ b/client/public/assets/icon/picker.svg
@@ -1,0 +1,5 @@
+<svg width="20" height="20" viewBox="0 0 20 20" fill="none" xmlns="http://www.w3.org/2000/svg">
+<rect x="1" y="1" width="18" height="18" rx="4" fill="#2AC1BC"/>
+<path d="M15.9902 6.99996L14.5802 5.57996L7.99023 12.17L5.41023 9.59996L3.99023 11.01L7.99023 15L15.9902 6.99996Z" fill="#FCFCFC"/>
+<rect x="1" y="1" width="18" height="18" rx="4" stroke="#2AC1BC" stroke-width="2"/>
+</svg>

--- a/client/public/assets/icon/rightArrow.svg
+++ b/client/public/assets/icon/rightArrow.svg
@@ -1,0 +1,3 @@
+<svg width="24" height="24" viewBox="0 0 24 24" fill="none" xmlns="http://www.w3.org/2000/svg">
+<path d="M8 20L16 12L8 4" stroke="#FCFCFC" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"/>
+</svg>

--- a/client/src/App.ts
+++ b/client/src/App.ts
@@ -1,26 +1,38 @@
 import Component from 'src/lib/component';
 
+import Header from 'src/components/Header';
 import { pageState } from 'src/store/page';
 import { getState } from 'src/lib/observer';
 
-export default class App extends Component {
-  constructor() {
-    super();
+type objType = {
+  [key: string]: any;
+};
+
+type StateType = {};
+type PropsType = {
+  isLoggedIn: boolean;
+};
+
+export default class App extends Component<StateType, PropsType> {
+  constructor(props: PropsType) {
+    super(props);
     this.addClass('app');
     this.keys = [pageState];
     this.subscribe();
   }
 
-  setTemplate() {
+  setTemplate(): string {
     return `
+      ${this.props?.isLoggedIn ? `<div id="app_header"></div>` : ''}
       <div id="page"></div>
     `;
   }
 
-  setComponents() {
+  setComponents(): objType {
     const { Page } = getState(pageState);
     return {
       page: new Page(),
+      app_header: new Header(),
     };
   }
 }

--- a/client/src/api/index.ts
+++ b/client/src/api/index.ts
@@ -1,0 +1,1 @@
+export default 10;

--- a/client/src/components/Header/index.ts
+++ b/client/src/components/Header/index.ts
@@ -1,0 +1,72 @@
+import Component from 'src/lib/component';
+
+import calendarIcon from 'public/assets/icon/calendarIcon.svg';
+import chartIcon from 'public/assets/icon/chartIcon.svg';
+import historyIcon from 'public/assets/icon/historyIcon.svg';
+import leftArrow from 'public/assets/icon/leftArrow.svg';
+import rightArrow from 'public/assets/icon/rightArrow.svg';
+
+import { router } from '../../../index';
+
+import _ from 'src/utils/dom';
+
+import './style.scss';
+
+export default class Header extends Component {
+  constructor() {
+    super();
+    this.addClass('header');
+  }
+
+  addEvent(): void {
+    _.onEvent(this, 'click', this.handleClick.bind(this));
+  }
+
+  setTemplate(): string {
+    const path = location.pathname;
+    const isHistory = path === '/';
+    const isCalendar = path === '/calendar';
+    const isChart = path === '/chart';
+
+    return `
+      <div class="header__content container row">
+        <h2 class="title">우아한 가계부</h2>
+        <div class="month-picker">
+          <button>
+            <img src=${leftArrow} alt='다음달'/>
+          </button>
+          <div class="month-display" >
+            <div class="month">7월</div>
+            <div class="year">2021</div>
+          </div>
+          <button>
+            <img src=${rightArrow} alt='이전달'/>
+          </button>
+        </div>
+        <div class="navigator">
+          <button class="nav-btn ${isHistory ? 'selected' : ''}" data-path="/">
+            <img src=${historyIcon} alt='거래내역 보기'/>
+          </button>
+          <button class="nav-btn ${isCalendar ? 'selected' : ''}" data-path="/calendar" >
+            <img src=${calendarIcon} alt='달력 보기'/>
+          </button>
+          <button class="nav-btn ${isChart ? 'selected' : ''}" data-path="/chart">
+            <img src=${chartIcon} alt='통계 보기'/>
+          </button>
+        </div>
+      </div>
+    `;
+  }
+
+  //TODO: 해결되지 않는 타입 무한굴래... as를 안쓰고 어떤식으로 해결해야될까...??
+  handleClick(e: Event): void {
+    const target = e.target as HTMLElement;
+    const button: HTMLButtonElement | null = target.closest('.navigator>button');
+    if (!button) return;
+
+    const path: string | void = button.dataset?.path;
+    if (path) router.push(path);
+  }
+}
+
+customElements.define('woowa-header', Header, { extends: 'header' });

--- a/client/src/components/Header/style.scss
+++ b/client/src/components/Header/style.scss
@@ -1,0 +1,49 @@
+header {
+  display: flex;
+  justify-content: center;
+  font-family: 'Do Hyeon', sans-serif;
+  color: var(--off-white-color);
+  background-color: var(--primary-color);
+
+  .header__content {
+    justify-content: space-between;
+    align-items: center;
+    padding: 40px 0;
+
+    .title {
+      font-size: var(--display-small-size);
+    }
+  }
+
+  .month-picker {
+    display: flex;
+    justify-content: space-between;
+    align-items: center;
+  }
+
+  .month-display {
+    text-align: center;
+    margin: 0 44px;
+
+    .month {
+      font-size: var(--display-large-size);
+    }
+    .year {
+      font-size: var(--display-small-size);
+    }
+    & > img {
+    }
+  }
+
+  .navigator {
+    display: flex;
+    gap: 27px;
+
+    button {
+      opacity: 0.5;
+    }
+    .selected {
+      opacity: 1;
+    }
+  }
+}

--- a/client/src/configs/routes.ts
+++ b/client/src/configs/routes.ts
@@ -1,10 +1,12 @@
 //page
 import MainPage from 'src/pages/MainPage';
 import CalendarPage from 'src/pages/CalendarPage';
+import ChartPage from 'src/pages/ChartPage';
 
 export const authorizedRoutes = {
   '/': MainPage,
   '/calendar': CalendarPage,
+  '/chart': ChartPage,
 };
 
 export const unauthorizedRoutes = {

--- a/client/src/constant/index.ts
+++ b/client/src/constant/index.ts
@@ -1,0 +1,1 @@
+export default 10;

--- a/client/src/lib/component/type.ts
+++ b/client/src/lib/component/type.ts
@@ -1,0 +1,7 @@
+export type objType = {
+  [key: string]: any;
+};
+
+export type Partial<T> = {
+  [P in keyof T]?: T[P];
+};

--- a/client/src/pages/CalendarPage/index.ts
+++ b/client/src/pages/CalendarPage/index.ts
@@ -1,0 +1,16 @@
+import Component from 'src/lib/component';
+
+export default class CalendarPage extends Component {
+  constructor() {
+    super();
+    this.addClass('page');
+  }
+
+  setTemplate(): string {
+    return `
+      <div id='calendar_page__list'>달력페이지</div>
+    `;
+  }
+}
+
+customElements.define('calendar-page', CalendarPage);

--- a/client/src/pages/ChartPage/index.ts
+++ b/client/src/pages/ChartPage/index.ts
@@ -1,0 +1,16 @@
+import Component from 'src/lib/component';
+
+export default class ChartPage extends Component {
+  constructor() {
+    super();
+    this.addClass('page');
+  }
+
+  setTemplate(): string {
+    return `
+      <div id='chart_page__list'>차트 페이지</div>
+    `;
+  }
+}
+
+customElements.define('chart-page', ChartPage);

--- a/client/src/pages/MainPage/index.ts
+++ b/client/src/pages/MainPage/index.ts
@@ -1,0 +1,16 @@
+import Component from 'src/lib/component';
+
+export default class MainPage extends Component {
+  constructor() {
+    super();
+    this.addClass('page', 'main-page');
+  }
+
+  setTemplate(): string {
+    return `
+      <div id='main_page__list'>메인페이지</div>
+    `;
+  }
+}
+
+customElements.define('main-page', MainPage);

--- a/client/src/style/global.scss
+++ b/client/src/style/global.scss
@@ -1,0 +1,30 @@
+@import url('https://fonts.googleapis.com/css2?family=Do+Hyeon&family=Noto+Sans+KR:wght@100;400;500;700&display=swap');
+
+.container {
+  width: 850px;
+  margin: 0 auto;
+}
+
+.row {
+  display: flex;
+  flex-direction: row;
+}
+
+.column {
+  display: flex;
+  flex-direction: column;
+}
+
+div,
+h1,
+h2,
+h3,
+h4,
+h5,
+h6,
+p,
+input,
+button,
+label {
+  font-family: 'Noto Sans KR', sans-serif;
+}

--- a/client/src/style/reset.scss
+++ b/client/src/style/reset.scss
@@ -1,0 +1,511 @@
+/* http://meyerweb.com/eric/tools/css/reset/ 
+   v2.0 | 20110126
+   License: none (public domain)
+*/
+
+html,
+body,
+div,
+span,
+applet,
+object,
+iframe,
+h1,
+h2,
+h3,
+h4,
+h5,
+h6,
+p,
+blockquote,
+pre,
+a,
+abbr,
+acronym,
+address,
+big,
+cite,
+code,
+del,
+dfn,
+em,
+img,
+ins,
+kbd,
+q,
+s,
+samp,
+small,
+strike,
+strong,
+sub,
+sup,
+tt,
+var,
+b,
+u,
+i,
+center,
+dl,
+dt,
+dd,
+ol,
+ul,
+li,
+fieldset,
+form,
+label,
+legend,
+table,
+caption,
+tbody,
+tfoot,
+thead,
+tr,
+th,
+td,
+article,
+aside,
+canvas,
+details,
+embed,
+figure,
+figcaption,
+footer,
+header,
+hgroup,
+menu,
+nav,
+output,
+ruby,
+section,
+summary,
+time,
+mark,
+audio,
+video {
+  margin: 0;
+  padding: 0;
+  border: 0;
+  font-size: 100%;
+  font: inherit;
+  vertical-align: baseline;
+}
+/* HTML5 display-role reset for older browsers */
+article,
+aside,
+details,
+figcaption,
+figure,
+footer,
+header,
+hgroup,
+menu,
+nav,
+section {
+  display: block;
+}
+body {
+  line-height: 1;
+}
+ol,
+ul {
+  list-style: none;
+}
+blockquote,
+q {
+  quotes: none;
+}
+blockquote:before,
+blockquote:after,
+q:before,
+q:after {
+  content: '';
+  content: none;
+}
+table {
+  border-collapse: collapse;
+  border-spacing: 0;
+}
+
+/*
+ * normalize.css v8.0.1
+ * MIT License
+ * github.com/necolas/normalize.css
+*/
+
+/* Document
+   ========================================================================== */
+
+/**
+ * 1. Correct the line height in all browsers.
+ * 2. Prevent adjustments of font size after orientation changes in iOS.
+ */
+
+html {
+  line-height: 1.15; /* 1 */
+  -webkit-text-size-adjust: 100%; /* 2 */
+}
+
+/* Sections
+   ========================================================================== */
+
+/**
+ * Remove the margin in all browsers.
+ */
+
+body {
+  margin: 0;
+}
+
+/**
+ * Render the `main` element consistently in IE.
+ */
+
+main {
+  display: block;
+}
+
+/**
+ * Correct the font size and margin on `h1` elements within `section` and
+ * `article` contexts in Chrome, Firefox, and Safari.
+ */
+
+h1 {
+  font-size: 2em;
+  margin: 0.67em 0;
+}
+
+/* Grouping content
+   ========================================================================== */
+
+/**
+ * 1. Add the correct box sizing in Firefox.
+ * 2. Show the overflow in Edge and IE.
+ */
+
+hr {
+  box-sizing: content-box; /* 1 */
+  height: 0; /* 1 */
+  overflow: visible; /* 2 */
+}
+
+/**
+ * 1. Correct the inheritance and scaling of font size in all browsers.
+ * 2. Correct the odd `em` font sizing in all browsers.
+ */
+
+pre {
+  font-family: monospace, monospace; /* 1 */
+  font-size: 1em; /* 2 */
+}
+
+/* Text-level semantics
+   ========================================================================== */
+
+/**
+ * Remove the gray background on active links in IE 10.
+ */
+
+a {
+  background-color: transparent;
+}
+
+/**
+ * 1. Remove the bottom border in Chrome 57-
+ * 2. Add the correct text decoration in Chrome, Edge, IE, Opera, and Safari.
+ */
+
+abbr[title] {
+  border-bottom: none; /* 1 */
+  text-decoration: underline; /* 2 */
+  text-decoration: underline dotted; /* 2 */
+}
+
+/**
+ * Add the correct font weight in Chrome, Edge, and Safari.
+ */
+
+b,
+strong {
+  font-weight: bolder;
+}
+
+/**
+ * 1. Correct the inheritance and scaling of font size in all browsers.
+ * 2. Correct the odd `em` font sizing in all browsers.
+ */
+
+code,
+kbd,
+samp {
+  font-family: monospace, monospace; /* 1 */
+  font-size: 1em; /* 2 */
+}
+
+/**
+ * Add the correct font size in all browsers.
+ */
+
+small {
+  font-size: 80%;
+}
+
+/**
+ * Prevent `sub` and `sup` elements from affecting the line height in
+ * all browsers.
+ */
+
+sub,
+sup {
+  font-size: 75%;
+  line-height: 0;
+  position: relative;
+  vertical-align: baseline;
+}
+
+sub {
+  bottom: -0.25em;
+}
+
+sup {
+  top: -0.5em;
+}
+
+/* Embedded content
+   ========================================================================== */
+
+/**
+ * Remove the border on images inside links in IE 10.
+ */
+
+img {
+  border-style: none;
+}
+
+/* Forms
+   ========================================================================== */
+
+/**
+ * 1. Change the font styles in all browsers.
+ * 2. Remove the margin in Firefox and Safari.
+ */
+
+button,
+input,
+optgroup,
+select,
+textarea {
+  font-family: inherit; /* 1 */
+  font-size: 100%; /* 1 */
+  line-height: 1.15; /* 1 */
+  margin: 0; /* 2 */
+}
+
+/**
+ * Show the overflow in IE.
+ * 1. Show the overflow in Edge.
+ */
+
+button,
+input {
+  /* 1 */
+  overflow: visible;
+}
+
+/**
+ * Remove the inheritance of text transform in Edge, Firefox, and IE.
+ * 1. Remove the inheritance of text transform in Firefox.
+ */
+
+button,
+select {
+  /* 1 */
+  text-transform: none;
+}
+
+/**
+ * Correct the inability to style clickable types in iOS and Safari.
+ */
+
+button,
+[type='button'],
+[type='reset'],
+[type='submit'] {
+  -webkit-appearance: button;
+}
+
+/**
+ * Remove the inner border and padding in Firefox.
+ */
+
+button::-moz-focus-inner,
+[type='button']::-moz-focus-inner,
+[type='reset']::-moz-focus-inner,
+[type='submit']::-moz-focus-inner {
+  border-style: none;
+  padding: 0;
+}
+
+/**
+ * Restore the focus styles unset by the previous rule.
+ */
+
+button:-moz-focusring,
+[type='button']:-moz-focusring,
+[type='reset']:-moz-focusring,
+[type='submit']:-moz-focusring {
+  outline: 1px dotted ButtonText;
+}
+
+/**
+ * Correct the padding in Firefox.
+ */
+
+fieldset {
+  padding: 0.35em 0.75em 0.625em;
+}
+
+/**
+ * 1. Correct the text wrapping in Edge and IE.
+ * 2. Correct the color inheritance from `fieldset` elements in IE.
+ * 3. Remove the padding so developers are not caught out when they zero out
+ *    `fieldset` elements in all browsers.
+ */
+
+legend {
+  box-sizing: border-box; /* 1 */
+  color: inherit; /* 2 */
+  display: table; /* 1 */
+  max-width: 100%; /* 1 */
+  padding: 0; /* 3 */
+  white-space: normal; /* 1 */
+}
+
+/**
+ * Add the correct vertical alignment in Chrome, Firefox, and Opera.
+ */
+
+progress {
+  vertical-align: baseline;
+}
+
+/**
+ * Remove the default vertical scrollbar in IE 10+.
+ */
+
+textarea {
+  overflow: auto;
+}
+
+/**
+ * 1. Add the correct box sizing in IE 10.
+ * 2. Remove the padding in IE 10.
+ */
+
+[type='checkbox'],
+[type='radio'] {
+  box-sizing: border-box; /* 1 */
+  padding: 0; /* 2 */
+}
+
+/**
+ * Correct the cursor style of increment and decrement buttons in Chrome.
+ */
+
+[type='number']::-webkit-inner-spin-button,
+[type='number']::-webkit-outer-spin-button {
+  height: auto;
+}
+
+/**
+ * 1. Correct the odd appearance in Chrome and Safari.
+ * 2. Correct the outline style in Safari.
+ */
+
+[type='search'] {
+  -webkit-appearance: textfield; /* 1 */
+  outline-offset: -2px; /* 2 */
+}
+
+/**
+ * Remove the inner padding in Chrome and Safari on macOS.
+ */
+
+[type='search']::-webkit-search-decoration {
+  -webkit-appearance: none;
+}
+
+/**
+ * 1. Correct the inability to style clickable types in iOS and Safari.
+ * 2. Change font properties to `inherit` in Safari.
+ */
+
+::-webkit-file-upload-button {
+  -webkit-appearance: button; /* 1 */
+  font: inherit; /* 2 */
+}
+
+/* Interactive
+   ========================================================================== */
+
+/*
+ * Add the correct display in Edge, IE 10+, and Firefox.
+ */
+
+details {
+  display: block;
+}
+
+/*
+ * Add the correct display in all browsers.
+ */
+
+summary {
+  display: list-item;
+}
+
+/* Misc
+   ========================================================================== */
+
+/**
+ * Add the correct display in IE 10+.
+ */
+
+template {
+  display: none;
+}
+
+/**
+ * Add the correct display in IE 10.
+ */
+
+[hidden] {
+  display: none;
+}
+
+/*
+  custom css reset
+*/
+div,
+button,
+main,
+section,
+input,
+figure {
+  box-sizing: border-box;
+}
+
+button,
+input {
+  outline: none;
+  border: none;
+  background: none;
+  padding: 0;
+}
+
+button {
+  cursor: pointer;
+  width: fit-content;
+  height: fit-content;
+}

--- a/client/src/style/variable.scss
+++ b/client/src/style/variable.scss
@@ -1,0 +1,39 @@
+:root {
+  --primary-color: #2ac1bc;
+  --primary-light-color: #a0e1e0;
+  --primary-dark-color: #219a95;
+  --error-color: #f45452;
+  --title-color: #1e2222;
+  --body-color: #626666;
+  --label-color: #8d9393;
+  --placeholder-color: #c1c5c5;
+  --line-color: #ccd3d3;
+  --background-color: #f5f5f5;
+  --off-white-color: #fcfcfc;
+
+  --category-color1: #6ed5eb;
+  --category-color2: #4cb8b8;
+  --category-color3: #94d3cc;
+  --category-color4: #4ca1de;
+  --category-color5: #d092e2;
+  --category-color6: #817dce;
+  --category-color7: #4a6cc3;
+  --category-color8: #b9d58c;
+  --category-color9: #e6d267;
+  --category-color10: #e2b765;
+
+  --display-small-size: 24px;
+  --display-large-size: 48px;
+
+  --bold-small-size: 12px;
+  --bold-medium-size: 14px;
+  --bold-large-size: 16px;
+
+  --body-regular-size: 16px;
+  --body-medium-size: 18px;
+  --body-large-size: 22px;
+}
+
+// Web fonts
+// font-family: 'Do Hyeon', sans-serif;
+// font-family: 'Noto Sans KR', sans-serif;

--- a/client/src/utils/dom.ts
+++ b/client/src/utils/dom.ts
@@ -1,0 +1,25 @@
+type createElemType = {
+  tagName: string;
+  classNames?: Array<string>;
+  value?: string;
+};
+
+type targetType = HTMLElement | Document;
+
+const _ = {
+  $: (selector: string, target: targetType = document): HTMLElement =>
+    target.querySelector(selector),
+  $$: (selector: string, target: targetType = document): NodeListOf<HTMLElement> =>
+    target.querySelectorAll(selector),
+  onEvent: (target: HTMLElement, eventType: string, fn: () => void): void => {
+    target.addEventListener(eventType, fn);
+  },
+  createElement: ({ tagName, classNames = [], value = '' }: createElemType): HTMLElement => {
+    const element = document.createElement(tagName);
+    element.classList.add(...classNames);
+    if (value) element.innerHTML = value;
+    return element;
+  },
+};
+
+export default _;

--- a/client/src/utils/dom.ts
+++ b/client/src/utils/dom.ts
@@ -7,11 +7,17 @@ type createElemType = {
 type targetType = HTMLElement | Document;
 
 const _ = {
-  $: (selector: string, target: targetType = document): HTMLElement =>
-    target.querySelector(selector),
-  $$: (selector: string, target: targetType = document): NodeListOf<HTMLElement> =>
-    target.querySelectorAll(selector),
-  onEvent: (target: HTMLElement, eventType: string, fn: () => void): void => {
+  $: (selector: string, target: targetType = document): HTMLElement | null => {
+    return target.querySelector(selector);
+  },
+  $$: (selector: string, target: targetType = document): NodeListOf<HTMLElement> => {
+    return target.querySelectorAll(selector);
+  },
+  onEvent: (
+    target: HTMLElement,
+    eventType: keyof HTMLElementEventMap,
+    fn: (e: Event) => void,
+  ): void => {
     target.addEventListener(eventType, fn);
   },
   createElement: ({ tagName, classNames = [], value = '' }: createElemType): HTMLElement => {

--- a/client/tsconfig.json
+++ b/client/tsconfig.json
@@ -2,7 +2,7 @@
   "compilerOptions": {
     /* Basic Options */
     // "incremental": true,                         /* Enable incremental compilation */
-    "target": "ESNEXT" /* Specify ECMAScript target version: 'ES3' (default), 'ES5', 'ES2015', 'ES2016', 'ES2017', 'ES2018', 'ES2019', 'ES2020', 'ES2021', or 'ESNEXT'. */,
+    "target": "es6" /* Specify ECMAScript target version: 'ES3' (default), 'ES5', 'ES2015', 'ES2016', 'ES2017', 'ES2018', 'ES2019', 'ES2020', 'ES2021', or 'ESNEXT'. */,
     "module": "ESNext" /* Specify module code generation: 'none', 'commonjs', 'amd', 'system', 'umd', 'es2015', 'es2020', or 'ESNext'. */,
     // "lib": [],                                   /* Specify library files to be included in the compilation. */
     "allowJs": true /* Allow javascript files to be compiled. */,
@@ -72,6 +72,5 @@
       "public/*": ["public/*"]
     }
   },
-  "include": ["./index.ts", "src/*.ts"],
   "exclude": ["node_modules", "build", "webpack.common.js", "webpack.dev.js", "webpack.prod.js"]
 }


### PR DESCRIPTION
#13  #25

## 개요
프론트엔드 베이스 코드 추가를 위한 유틸함수 및 헤더 협업

## 변경사항
* DOM 유틸함수 추가
* 글로벌 스타일 적용
* 아이콘 추가
* 컴포넌트 프레임워크 타입 설정
* 헤더 마크업 및 라우터 추가
* 기본 페이지 설정

## 참고사항

## 추가 구현 필요사항

## 스크린샷
