### PR TITLE
차트 페이지 마크업

### DIFF
--- a/client/index.scss
+++ b/client/index.scss
@@ -1,5 +1,5 @@
-@import './src/style/global.scss';
 @import './src/style/reset.scss';
+@import './src/style/global.scss';
 @import './src/style/variable.scss';
 
 div {

--- a/client/src/pages/ChartPage/drawCoordinatePlane.ts
+++ b/client/src/pages/ChartPage/drawCoordinatePlane.ts
@@ -1,0 +1,32 @@
+function drawCoordinatePlane(canvasID: string): void {
+  const canvas: HTMLCanvasElement = document.getElementById(canvasID);
+
+  if (!canvas) {
+    return;
+  }
+
+  const ctx: CanvasRenderingContext2D = canvas.getContext('2d');
+
+  const coordinateWidth = 750;
+  const coordinateHeight = 300;
+  const gridHeight = 25;
+  const gridWidth = 32.6;
+
+  for (let i = 0; i < 13; i++) {
+    ctx.strokeStyle = '#ccd3d3';
+    ctx?.beginPath();
+    ctx?.moveTo(0, gridHeight * i);
+    ctx?.lineTo(coordinateWidth, gridHeight * i);
+    ctx?.stroke();
+  }
+
+  for (let i = 0; i < 24; i++) {
+    ctx.strokeStyle = '#ccd3d3';
+    ctx?.beginPath();
+    ctx?.moveTo(gridWidth * i, 0);
+    ctx?.lineTo(gridWidth * i, coordinateHeight);
+    ctx?.stroke();
+  }
+}
+
+export default drawCoordinatePlane;

--- a/client/src/pages/ChartPage/drawCoordinatePlane.ts
+++ b/client/src/pages/ChartPage/drawCoordinatePlane.ts
@@ -1,5 +1,5 @@
-function drawCoordinatePlane(canvasID: string): void {
-  const canvas: HTMLCanvasElement = document.getElementById(canvasID);
+function drawCoordinatePlane(element: HTMLElement, canvasID: string): void {
+  const canvas: HTMLCanvasElement = element.querySelector(`#${canvasID}`);
 
   if (!canvas) {
     return;

--- a/client/src/pages/ChartPage/drawPieChart.ts
+++ b/client/src/pages/ChartPage/drawPieChart.ts
@@ -1,0 +1,24 @@
+function drawPieChart(canvasID: string): void {
+  const canvas: HTMLCanvasElement | void = document.getElementById(canvasID);
+
+  if (!canvas) {
+    return;
+  }
+
+  const ctx = canvas.getContext('2d');
+
+  const x = 127;
+  const y = 127;
+  const radius = 127;
+  const startAngle = (Math.PI / 180) * 90 * -1;
+  const endAngle = (Math.PI / 180) * 120;
+
+  ctx.fillStyle = '#2ac1bc';
+  ctx?.beginPath();
+  ctx?.moveTo(x, y);
+  ctx?.arc(x, y, radius, startAngle, endAngle);
+  ctx?.closePath();
+  ctx?.fill();
+}
+
+export default drawPieChart;

--- a/client/src/pages/ChartPage/drawPieChart.ts
+++ b/client/src/pages/ChartPage/drawPieChart.ts
@@ -1,5 +1,5 @@
-function drawPieChart(canvasID: string): void {
-  const canvas: HTMLCanvasElement | void = document.getElementById(canvasID);
+function drawPieChart(element: HTMLElement, canvasID: string): void {
+  const canvas: HTMLCanvasElement = element.querySelector(`#${canvasID}`);
 
   if (!canvas) {
     return;

--- a/client/src/pages/ChartPage/index.ts
+++ b/client/src/pages/ChartPage/index.ts
@@ -9,16 +9,11 @@ export default class ChartPage extends Component {
   constructor() {
     super();
     this.addClass('page');
+    this.drawChart();
   }
 
   addEvent(): void {
     this.addEventListener('click', this.handleClick.bind(this));
-    setTimeout(() => {
-      drawPieChart('pie-chart');
-    }, 0);
-    setTimeout(() => {
-      drawCoordinatePlane('line-chart');
-    }, 0);
   }
 
   setTemplate(): string {
@@ -64,6 +59,11 @@ export default class ChartPage extends Component {
     const button: HTMLTableRowElement | null = target.closest('tr');
     if (!button) return;
     console.log(button);
+  }
+
+  drawChart(): void {
+    drawPieChart(this, 'pie-chart');
+    drawCoordinatePlane(this, 'line-chart');
   }
 }
 

--- a/client/src/pages/ChartPage/index.ts
+++ b/client/src/pages/ChartPage/index.ts
@@ -1,15 +1,69 @@
 import Component from 'src/lib/component';
 
+import drawPieChart from './drawPieChart';
+import drawCoordinatePlane from './drawCoordinatePlane';
+
+import './style.scss';
+
 export default class ChartPage extends Component {
   constructor() {
     super();
     this.addClass('page');
   }
 
+  addEvent(): void {
+    this.addEventListener('click', this.handleClick.bind(this));
+    setTimeout(() => {
+      drawPieChart('pie-chart');
+    }, 0);
+    setTimeout(() => {
+      drawCoordinatePlane('line-chart');
+    }, 0);
+  }
+
   setTemplate(): string {
     return `
-      <div id='chart_page__list'>차트 페이지</div>
+      <section class="container box row">
+        <div class="pie-chart-container">
+          <canvas id="pie-chart" width="254" height="254"></canvas>
+        </div>
+        <div class="statistic-container">
+          <h3>이번 달 지출 금액 244,600원</h3>
+          <table>
+            <colgroup>
+              <col>
+              <col>
+              <col width="50%">
+            </colgruop>
+            <tbody>
+              <tr class="selected">
+                <td class="category">생활</td>
+                <td class="percentage">64%</td>
+                <td class="money">534,600원</td>
+              </tr>
+              <tr>
+                <td class="category">생활</td>
+                <td class="percentage">64%</td>
+                <td class="money">534,600원</td>
+              </tr>
+            </tbody>
+          </table>
+        </div>
+      </section>
+      <section class="container box">
+        <h3>생활 카테고리 소비 추이</h3>
+        <canvas id="line-chart" width="750" height="310"></canvas>
+      </section>
+      <section class="container">
+      </section>
     `;
+  }
+
+  handleClick(e: Event): void {
+    const target = e.target as HTMLElement;
+    const button: HTMLTableRowElement | null = target.closest('tr');
+    if (!button) return;
+    console.log(button);
   }
 }
 

--- a/client/src/pages/ChartPage/style.scss
+++ b/client/src/pages/ChartPage/style.scss
@@ -1,0 +1,63 @@
+chart-page {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  padding: 32px 36px;
+
+  section {
+    position: relative;
+
+    &.container {
+      margin-bottom: 16px;
+    }
+    &.box {
+      padding: 32px 50px;
+      border: 1px solid var(--line-color);
+      border-radius: 10px;
+      box-shadow: 0px 4px 4px rgba(0, 0, 0, 0.1), 0px 4px 20px rgba(0, 0, 0, 0.1);
+    }
+
+    h3 {
+      font-size: var(--body-large-size);
+      color: var(--title-color);
+      margin-bottom: 32px;
+    }
+
+    .pie-chart-container {
+      margin: 0 90px 0 40px;
+      display: flex;
+      align-items: center;
+    }
+    .statistic-container {
+      display: flex;
+      flex-direction: column;
+      flex: 1;
+
+      table {
+        width: 100%;
+        table-layout: fixed;
+
+        tr {
+          cursor: pointer;
+
+          &.selected {
+            background-color: var(--background-color);
+          }
+        }
+
+        td {
+          padding: 16px;
+          border-bottom: 1px solid var(--line-color);
+
+          color: var(--title-color);
+          font-size: var(--body-medium-size);
+
+          &.money {
+            text-align: right;
+            font-weight: 500;
+          }
+        }
+      }
+    }
+  }
+}


### PR DESCRIPTION
#12 

## 개요
차트 페이지 마크업

## 변경사항
* 차트페이지 마크업
* 글로벌 스타일 import 순서 변경(`reset.scss`가 `global.scss`보다 먼저 import되어 덮어씌어짐)
* 캔버스 그림 함수 프레임 추가

## 참고사항

## 추가 구현 필요사항
* 차트 페이지에 거래내역 추가
* 거래내역 종류 뱃지 추가
* 캔버스로 차트 구현

## 스크린샷
![스크린샷 2021-07-29 오후 6 55 20](https://user-images.githubusercontent.com/35324795/127471918-3ab360c4-8d37-4a1b-b899-b52eca07d3f4.png)
