### PR TITLE
토큰 유효성 검사 미들웨어

### DIFF
--- a/api/utils/errorHandler.ts
+++ b/api/utils/errorHandler.ts
@@ -13,6 +13,10 @@ function errorHandler(errCode: string): ErrorType {
       return { statusCode: 401, errorMessage: '유효하지 않은 토큰입니다.' };
     case 'auth/existing-email':
       return { statusCode: 409, errorMessage: '이미 가입된 이메일입니다.' };
+    case 'auth/unauthorized-token':
+      return { statusCode: 409, errorMessage: '인증받지 않은 토큰입니다.' };
+    case 'auth/auth/need-re-signin':
+      return { statusCode: 409, errorMessage: '재로그인이 필요합니다.' };
     default:
       return { statusCode: 500, errorMessage: '다시 시도해주세요.' };
   }


### PR DESCRIPTION
#23

## 개요
토큰 유효성 검사 미들웨어

## 변경사항
* `validateToken` 미들웨어 추가
* jwt 유틸함수 추가

## 참고사항
`accessToken` 역시 쿠키로 관리해야 할 수 있습니다. 액세스 토큰이 만료되었을 경우 재발행하는 방법은 응답으로 보내야 하는데, 미들웨어에서는 응답으로 보내게 되면 그 응답이 끊겨버려 액세스 토큰을 재발행하고 등록하기 어렵습니다.

## 추가 구현 필요사항
* Oauth

## 스크린샷
