### PR TITLE
[BE] 달력 통계 조회 API 구현

### DIFF
--- a/api/types/transaction.ts
+++ b/api/types/transaction.ts
@@ -34,3 +34,15 @@ export interface TransactionDataType {
   totalExpenditure: number;
   transaction: Array<DayTransactionType>;
 }
+
+export interface CalendarStatisticsType {
+  totalIncome: number;
+  totalExpenditure: number;
+  statistics: {
+    [key: number]: {
+      income: number;
+      expenditure: number;
+      total: number;
+    };
+  };
+}


### PR DESCRIPTION
#85 

## 개요

달력 통계 조회 API 구현

## 변경사항

반환 타입

```
{
  totalIncome: number;
  totalExpenditure: number;
  statistics: {
    [key: number]: {
      income: number;
      expenditure: number;
      total: number;
    };
  };
}
```

## 참고사항

## 추가 구현 필요사항

리팩토링 시 함수 분리를 하면 좋을 것 같습니다

## 스크린샷
