### PR TITLE
로그인 / 회원가입 페이지 API 연동

### DIFF
--- a/client/src/configs/urls.ts
+++ b/client/src/configs/urls.ts
@@ -1,0 +1,5 @@
+const BASE_URL = 'http://localhost:4000';
+
+export const SIGNIN_URL = `${BASE_URL}/auth/signin`;
+export const SIGNUP_URL = `${BASE_URL}/auth/signup`;
+export const SIGNOUT_URL = `${BASE_URL}/auth/signout`;

--- a/client/src/pages/SignInPage/index.ts
+++ b/client/src/pages/SignInPage/index.ts
@@ -3,9 +3,22 @@ import Component from 'src/lib/component';
 import { router } from '../../../index';
 import { setState } from 'src/lib/observer';
 import { isLoggedInState } from 'src/store/page';
-import githubIcon from 'public/assets/icon/github.svg';
+import fetchWrapper from 'src/utils/fetchWrapper';
+import getValidityMessage from 'src/utils/getValidityMessages';
 
+import { SIGNIN_URL } from 'src/configs/urls';
+
+import githubIcon from 'public/assets/icon/github.svg';
 import './style.scss';
+
+interface FormType extends EventTarget {
+  email?: HTMLInputElement;
+  password?: HTMLInputElement;
+  'password-check'?: HTMLInputElement;
+}
+
+const DEMO_EMAIL = 'test@woowahan.com';
+const DEMO_PASSWORD = '13579';
 
 export default class SignInPage extends Component {
   constructor() {
@@ -20,8 +33,20 @@ export default class SignInPage extends Component {
           <h3 class="logo">우아한 가계부</h3>
           <h1 class="title">로그인</h1>
           <form>
-            <input id="email" placeholder="이메일" type="email" />
-            <input id="password" placeholder="비밀번호" type="password" />
+            <input
+              id="email"
+              placeholder="이메일"
+              type="email"
+              required
+            />
+            <input
+              id="password"
+              placeholder="비밀번호"
+              type="password"
+              minlength="5"
+              required
+            />
+            <span class="error-message" id="error-message"></span>
             <button type="submit">로그인</button>
           </form>
           <div class="sub-buttons">
@@ -43,25 +68,106 @@ export default class SignInPage extends Component {
   addEvent(): void {
     this.addEventListener('click', this.handleButtonClick.bind(this));
     this.addEventListener('submit', this.handleSubmit.bind(this));
+    this.querySelector('#email')?.addEventListener('invalid', this.handleInputError.bind(this));
+    this.querySelector('#password')?.addEventListener('invalid', this.handleInputError.bind(this));
   }
 
-  handleButtonClick(e: Event): void {
-    const target = e.target as HTMLElement;
-    const button: HTMLButtonElement | null = target.closest('button');
-    if (!button) return;
+  async signInDemo(): Promise<void> {
+    try {
+      const res = await fetchWrapper(SIGNIN_URL, 'POST', {
+        email: DEMO_EMAIL,
+        password: DEMO_PASSWORD,
+      });
 
-    if (button.id === 'signup') {
-      router.push('/signup');
-    }
-    if (button.id === 'signin-demo') {
+      if (!res.success) {
+        this.displayError(res.errorMessage);
+        return;
+      }
+
+      const { accessToken } = res;
+      localStorage.setItem('_at', accessToken);
+
       setState(isLoggedInState)(true);
-      router.push('/');
+      router.replace('/');
+    } catch (err) {
+      console.log(err);
     }
   }
 
-  handleSubmit(e: Event): void {
+  displayError(message: string): void {
+    const $errorMessage = this.querySelector(`#error-message`);
+    if (!$errorMessage) {
+      return;
+    }
+
+    $errorMessage.textContent = message;
+  }
+
+  handleInputError(e: Event): void {
     e.preventDefault();
-    console.log('submit!');
+
+    const $input: HTMLInputElement = e.target as HTMLInputElement;
+
+    const type = $input.id === 'email' ? 'email' : 'password';
+    const errorMessage = getValidityMessage(type, $input.validity);
+
+    if (!errorMessage) {
+      return;
+    }
+    this.displayError(errorMessage);
+  }
+
+  async handleButtonClick(e: Event): Promise<void> {
+    try {
+      const target = e.target as HTMLElement;
+      const button: HTMLButtonElement | null = target.closest('button');
+      if (!button) return;
+
+      button.disabled = true;
+
+      if (button.id === 'signup') {
+        router.push('/signup');
+      }
+      if (button.id === 'signin-demo') {
+        await this.signInDemo();
+      }
+
+      button.disabled = false;
+    } catch (err) {
+      console.log(err);
+    }
+  }
+
+  async handleSubmit(e: Event): Promise<void> {
+    try {
+      e.preventDefault();
+      if (!e.target) {
+        return;
+      }
+
+      const $form: FormType = e.target;
+
+      const email = $form.email?.value;
+      const password = $form.password?.value;
+
+      const res = await fetchWrapper(SIGNIN_URL, 'POST', {
+        email,
+        password,
+      });
+
+      if (!res.success) {
+        this.displayError(res.errorMessage);
+        return;
+      }
+
+      const { accessToken } = res;
+      localStorage.setItem('_at', accessToken);
+
+      setState(isLoggedInState)(true);
+      router.replace('/');
+    } catch (err) {
+      console.log(err);
+    }
   }
 }
 

--- a/client/src/pages/SignInPage/style.scss
+++ b/client/src/pages/SignInPage/style.scss
@@ -32,6 +32,7 @@ main.signin__main {
     flex-direction: column;
     align-items: center;
     width: 100%;
+    position: relative;
 
     input {
       width: 100%;
@@ -61,6 +62,16 @@ main.signin__main {
       &:hover {
         background-color: var(--primary-dark-color);
       }
+    }
+
+    .error-message {
+      height: 0;
+      position: relative;
+      z-index: 10;
+      font-size: var(--bold-small-size);
+      color: var(--error-color);
+      align-self: flex-start;
+      margin-bottom: 16px;
     }
   }
 

--- a/client/src/pages/SignUpPage/index.ts
+++ b/client/src/pages/SignUpPage/index.ts
@@ -1,8 +1,10 @@
 import Component from 'src/lib/component';
 
 import { router } from '../../../index';
+import { setState } from 'src/lib/observer';
+import { isLoggedInState } from 'src/store/page';
 import fetchWrapper from 'src/utils/fetchWrapper';
-import checkInputValidity from 'src/utils/checkInputValidity';
+import getValidityMessage from 'src/utils/getValidityMessages';
 
 import { SIGNUP_URL } from 'src/configs/urls';
 
@@ -27,9 +29,10 @@ export default class SignUpPage extends Component {
           <h3 class="logo">우아한 가계부</h3>
           <h1 class="title">회원가입</h1>
           <form>
-            <input id="email" placeholder="이메일" type="email" />
-            <input id="password" placeholder="비밀번호" type="password" />
+            <input id="email" placeholder="이메일" type="email" required />
+            <input id="password" placeholder="비밀번호" type="password" minlength="5" required />
             <input id="password-check" placeholder="비밀번호 확인" type="password" />
+            <span class="error-message" id="error-message"></span>
             <button type="submit">회원가입</button>
           </form>
           <div class="sub-buttons">
@@ -44,16 +47,45 @@ export default class SignUpPage extends Component {
   addEvent(): void {
     this.addEventListener('click', this.handleButtonClick.bind(this));
     this.addEventListener('submit', this.handleSubmit.bind(this));
+    this.querySelector('#email')?.addEventListener('invalid', this.handleInputError.bind(this));
+    this.querySelector('#password')?.addEventListener('invalid', this.handleInputError.bind(this));
+    this.querySelector('#password-check')?.addEventListener(
+      'invalid',
+      this.handleInputError.bind(this),
+    );
   }
 
   handleButtonClick(e: Event): void {
     const target = e.target as HTMLElement;
     const button: HTMLButtonElement | null = target.closest('button');
     if (!button) return;
-    console.log(button);
+
     if (button.id === 'signin') {
       router.push('/');
     }
+  }
+
+  displayError(message: string): void {
+    const $errorMessage = this.querySelector(`#error-message`);
+    if (!$errorMessage) {
+      return;
+    }
+
+    $errorMessage.textContent = message;
+  }
+
+  handleInputError(e: Event): void {
+    e.preventDefault();
+
+    const $input: HTMLInputElement = e.target as HTMLInputElement;
+
+    const type = $input.id === 'email' ? 'email' : 'password';
+    const errorMessage = getValidityMessage(type, $input.validity);
+
+    if (!errorMessage) {
+      return;
+    }
+    this.displayError(errorMessage);
   }
 
   async handleSubmit(e: Event): Promise<void> {
@@ -69,30 +101,8 @@ export default class SignUpPage extends Component {
       const password = $form.password?.value;
       const passwordCheck = $form['password-check']?.value;
 
-      if (!email) {
-        alert('이메일을 입력해주세요.');
-        return;
-      }
-
-      const isEmailValid = checkInputValidity('email', email);
-      if (!isEmailValid) {
-        alert('이메일 형식을 확인해주세요');
-        return;
-      }
-
-      if (!password) {
-        alert('비밀번호를 입력해주세요.');
-        return;
-      }
-
-      const isPasswordValid = checkInputValidity('password', password);
-      if (!isPasswordValid) {
-        alert('비밀번호 형식이 다릅니다.');
-        return;
-      }
-
       if (password !== passwordCheck) {
-        alert('비밀번호와 비밀번호 확인이 서로 다릅니다.');
+        this.displayError('비밀번호와 비밀번호 확인이 서로 다릅니다.');
         return;
       }
 
@@ -110,7 +120,7 @@ export default class SignUpPage extends Component {
 
       localStorage.setItem('_at', accessToken);
 
-      // TODO: 라우터에서 isLoggedIn을 true로 만들어줘야 함
+      setState(isLoggedInState)(true);
       router.replace('/');
     } catch (err) {
       console.log(err);

--- a/client/src/pages/SignUpPage/index.ts
+++ b/client/src/pages/SignUpPage/index.ts
@@ -1,8 +1,18 @@
 import Component from 'src/lib/component';
 
 import { router } from '../../../index';
+import fetchWrapper from 'src/utils/fetchWrapper';
+import checkInputValidity from 'src/utils/checkInputValidity';
+
+import { SIGNUP_URL } from 'src/configs/urls';
 
 import './style.scss';
+
+interface FormType extends EventTarget {
+  email?: HTMLInputElement;
+  password?: HTMLInputElement;
+  'password-check'?: HTMLInputElement;
+}
 
 export default class SignUpPage extends Component {
   constructor() {
@@ -46,9 +56,65 @@ export default class SignUpPage extends Component {
     }
   }
 
-  handleSubmit(e: Event): void {
-    e.preventDefault();
-    console.log('submit!');
+  async handleSubmit(e: Event): Promise<void> {
+    try {
+      e.preventDefault();
+      if (!e.target) {
+        return;
+      }
+
+      const $form: FormType = e.target;
+
+      const email = $form.email?.value;
+      const password = $form.password?.value;
+      const passwordCheck = $form['password-check']?.value;
+
+      if (!email) {
+        alert('이메일을 입력해주세요.');
+        return;
+      }
+
+      const isEmailValid = checkInputValidity('email', email);
+      if (!isEmailValid) {
+        alert('이메일 형식을 확인해주세요');
+        return;
+      }
+
+      if (!password) {
+        alert('비밀번호를 입력해주세요.');
+        return;
+      }
+
+      const isPasswordValid = checkInputValidity('password', password);
+      if (!isPasswordValid) {
+        alert('비밀번호 형식이 다릅니다.');
+        return;
+      }
+
+      if (password !== passwordCheck) {
+        alert('비밀번호와 비밀번호 확인이 서로 다릅니다.');
+        return;
+      }
+
+      const res = await fetchWrapper(SIGNUP_URL, 'POST', {
+        email,
+        password,
+      });
+
+      if (!res.success) {
+        alert(res.errorMessage);
+        return;
+      }
+
+      const { accessToken } = res;
+
+      localStorage.setItem('_at', accessToken);
+
+      // TODO: 라우터에서 isLoggedIn을 true로 만들어줘야 함
+      router.replace('/');
+    } catch (err) {
+      console.log(err);
+    }
   }
 }
 

--- a/client/src/pages/SignUpPage/style.scss
+++ b/client/src/pages/SignUpPage/style.scss
@@ -1,4 +1,4 @@
-main.signin__main {
+main.signup__main {
   display: flex;
   justify-content: center;
   align-items: center;
@@ -32,6 +32,7 @@ main.signin__main {
     flex-direction: column;
     align-items: center;
     width: 100%;
+    position: relative;
 
     input {
       width: 100%;
@@ -61,6 +62,16 @@ main.signin__main {
       &:hover {
         background-color: var(--primary-dark-color);
       }
+    }
+
+    .error-message {
+      height: 0;
+      position: relative;
+      z-index: 10;
+      font-size: var(--bold-small-size);
+      color: var(--error-color);
+      align-self: flex-start;
+      margin-bottom: 16px;
     }
   }
 

--- a/client/src/utils/checkInputValidity.ts
+++ b/client/src/utils/checkInputValidity.ts
@@ -1,0 +1,21 @@
+type InputType = 'email' | 'password';
+
+function checkInputValidity(type: InputType, input: string): boolean {
+  let regex: RegExp;
+
+  switch (type) {
+    case 'email':
+      regex = /[0-9a-zA-Z]([-_.]?[0-9a-zA-Z])*@[0-9a-zA-Z]([-_.]?[0-9a-zA-Z])*.[a-zA-Z]$/i;
+      break;
+    case 'password':
+      regex = /^(?=.*[A-Za-z])(?=.*\d)[A-Za-z\d]{8,}$/;
+      break;
+    default:
+      regex = /.?/;
+      break;
+  }
+
+  return regex.test(input);
+}
+
+export default checkInputValidity;

--- a/client/src/utils/fetchWrapper.ts
+++ b/client/src/utils/fetchWrapper.ts
@@ -24,7 +24,7 @@ async function fetchWrapper(url: string, method: MethodType, body: ObjectType): 
 
     const response = await res.json();
 
-    return response;
+    return { success: true, ...response };
   } catch (err) {
     console.log(err);
   }

--- a/client/src/utils/fetchWrapper.ts
+++ b/client/src/utils/fetchWrapper.ts
@@ -1,0 +1,33 @@
+type MethodType = 'GET' | 'POST' | 'PUT' | 'DELETE' | 'HEAD';
+
+type ObjectType = {
+  [key in string]: any;
+};
+
+async function fetchWrapper(url: string, method: MethodType, body: ObjectType): Promise<any> {
+  try {
+    const token = window.localStorage.getItem('_at') || '';
+
+    const res = await fetch(url, {
+      method,
+      headers: {
+        'Content-Type': 'application/json',
+        Authorization: `Bearer ${token}`,
+      },
+      body: JSON.stringify(body),
+    });
+
+    if (!res.ok) {
+      const { errorMessage } = await res.json();
+      return { success: false, errorMessage };
+    }
+
+    const response = await res.json();
+
+    return response;
+  } catch (err) {
+    console.log(err);
+  }
+}
+
+export default fetchWrapper;

--- a/client/src/utils/getValidityMessages.ts
+++ b/client/src/utils/getValidityMessages.ts
@@ -1,0 +1,64 @@
+type InputType = 'email' | 'password';
+
+const validityMessage = {
+  badInput: '잘못된 입력입니다',
+  patternMismatch: '형식을 맞춰주세요',
+  rangeOverflow: '최대범위를 큽니다',
+  rangeUnderflow: '최소범위 보다 작습니다',
+  stepMismatch: '',
+  tooLong: '너무 깁니다',
+  tooShort: '너무 짧습니다',
+  typeMismatch: '올바른 형식을 맞춰주세요',
+  valueMissing: '값을 입력해주세요',
+};
+
+const validityMessages = {
+  email: {
+    ...validityMessage,
+    badInput: '잘못된 입력입니다',
+    typeMismatch: '이메일 형식에 맞게 입력해주세요',
+    valueMissing: '이메일을 입력해주세요',
+  },
+  password: {
+    ...validityMessage,
+    badInput: '잘못된 입력입니다',
+    tooShort: '비밀번호는 8자 이상입니다',
+    valueMissing: '비밀번호를 입력해주세요',
+  },
+};
+
+function getValidityMessage(type: InputType, validity: ValidityState): string {
+  const message = validityMessages[type];
+
+  if (validity.badInput) {
+    return message.badInput;
+  }
+  if (validity.patternMismatch) {
+    return message.patternMismatch;
+  }
+  if (validity.rangeOverflow) {
+    return message.rangeOverflow;
+  }
+  if (validity.rangeUnderflow) {
+    return message.rangeUnderflow;
+  }
+  if (validity.stepMismatch) {
+    return message.stepMismatch;
+  }
+  if (validity.tooLong) {
+    return message.tooLong;
+  }
+  if (validity.tooShort) {
+    return message.tooShort;
+  }
+  if (validity.typeMismatch) {
+    return message.typeMismatch;
+  }
+  if (validity.valueMissing) {
+    return message.valueMissing;
+  }
+
+  return '';
+}
+
+export default getValidityMessage;


### PR DESCRIPTION
#88 

## 개요
로그인 / 회원가입 페이지 API 연동

## 변경사항
* 로그인 페이지 API 연동
* 회원가입 페이지 API 연동
* HTML input 커스텀 validation 기능 추가
* 로그인 / 회원가입 페이지 에러메세지 스타일 추가

## 참고사항
input validation은 HTML의 ValidityState API를 사용했습니다.

## 추가 구현 필요사항

## 스크린샷
