### PR TITLE
[FE] 메인화면 거래내역 패치 후 렌더링

### DIFF
--- a/api/services/transaction.ts
+++ b/api/services/transaction.ts
@@ -231,7 +231,7 @@ const parseTransactionByDate = (
     dayRecord.transaction = [record];
   });
 
-  result.push(dayRecord);
+  if (dayRecord.date) result.push(dayRecord);
 
   return result;
 };

--- a/client/src/api/transaction.ts
+++ b/client/src/api/transaction.ts
@@ -1,0 +1,22 @@
+import { getState, setState } from 'src/lib/observer';
+import { dateState, transactionPriceTypeState, transactionState } from 'src/store/transaction';
+
+export const getTransaction = async (): Promise<void> => {
+  const { year, month } = getState(dateState);
+  const { isIncome, isExpenditure } = getState(transactionPriceTypeState);
+
+  const token = localStorage.getItem('token');
+  const query = `year=${year}&month=${month}&isIncome=${isIncome}&isExpenditure=${isExpenditure}`;
+
+  const res = await fetch(`/transaction?${query}`, {
+    headers: {
+      'Content-Type': 'application/json',
+      Authorization: `Bearer ${token}`,
+    },
+  });
+  const { data } = await res.json();
+  setState(transactionState)(data);
+  return data;
+};
+
+export const createTransaction = async () => {};

--- a/client/src/components/Header/index.ts
+++ b/client/src/components/Header/index.ts
@@ -14,6 +14,7 @@ import { dateState, DateType } from 'src/store/transaction';
 import { router } from '../../../index';
 
 import './style.scss';
+import { getTransaction } from 'src/api/transaction';
 
 export default class Header extends Component {
   setDate: (newState: DateType) => void;
@@ -71,8 +72,14 @@ export default class Header extends Component {
     const target = e.target as HTMLElement;
     const currentDate = getState(dateState);
 
-    if (this.isLeftArrow(target)) this.setDate(getPrevMonth(currentDate));
-    if (this.isRightArrow(target)) this.setDate(getNextMonth(currentDate));
+    if (this.isLeftArrow(target)) {
+      this.setDate(getPrevMonth(currentDate));
+      getTransaction();
+    }
+    if (this.isRightArrow(target)) {
+      this.setDate(getNextMonth(currentDate));
+      getTransaction();
+    }
 
     const button: HTMLButtonElement | null = target.closest('.navigator>button');
     if (!button) return;

--- a/client/src/components/Header/index.ts
+++ b/client/src/components/Header/index.ts
@@ -1,3 +1,4 @@
+import { getState, setState } from 'src/lib/observer';
 import Component from 'src/lib/component';
 
 import calendarIcon from 'public/assets/icon/calendarIcon.svg';
@@ -6,15 +7,21 @@ import historyIcon from 'public/assets/icon/historyIcon.svg';
 import leftArrow from 'public/assets/icon/leftArrow.svg';
 import rightArrow from 'public/assets/icon/rightArrow.svg';
 
-import { router } from '../../../index';
-
 import _ from 'src/utils/dom';
+import { getNextMonth, getPrevMonth } from 'src/utils/date';
+import { dateState, DateType } from 'src/store/transaction';
+
+import { router } from '../../../index';
 
 import './style.scss';
 
 export default class Header extends Component {
+  setDate: (newState: DateType) => void;
   constructor() {
     super();
+    this.setDate = setState(dateState);
+    this.keys = [dateState];
+    this.subscribe();
     this.addClass('header');
   }
 
@@ -23,6 +30,7 @@ export default class Header extends Component {
   }
 
   setTemplate(): string {
+    const { year, month } = getState(dateState);
     const path = location.pathname;
     const isHistory = path === '/';
     const isCalendar = path === '/calendar';
@@ -32,14 +40,14 @@ export default class Header extends Component {
       <div class="header__content container row">
         <h2 class="title">우아한 가계부</h2>
         <div class="month-picker">
-          <button>
+          <button id="left-arrow">
             <img src=${leftArrow} alt='다음달'/>
           </button>
           <div class="month-display" >
-            <div class="month">7월</div>
-            <div class="year">2021</div>
+            <div class="month">${month}월</div>
+            <div class="year">${year}</div>
           </div>
-          <button>
+          <button id="right-arrow">
             <img src=${rightArrow} alt='이전달'/>
           </button>
         </div>
@@ -61,11 +69,23 @@ export default class Header extends Component {
   //TODO: 해결되지 않는 타입 무한굴래... as를 안쓰고 어떤식으로 해결해야될까...??
   handleClick(e: Event): void {
     const target = e.target as HTMLElement;
+    const currentDate = getState(dateState);
+
+    if (this.isLeftArrow(target)) this.setDate(getPrevMonth(currentDate));
+    if (this.isRightArrow(target)) this.setDate(getNextMonth(currentDate));
+
     const button: HTMLButtonElement | null = target.closest('.navigator>button');
     if (!button) return;
 
     const path: string | void = button.dataset?.path;
     if (path) router.push(path);
+  }
+
+  isLeftArrow(target: HTMLElement): boolean {
+    return !!target.closest('#left-arrow');
+  }
+  isRightArrow(target: HTMLElement): boolean {
+    return !!target.closest('#right-arrow');
   }
 }
 

--- a/client/src/components/Header/style.scss
+++ b/client/src/components/Header/style.scss
@@ -22,6 +22,7 @@ header {
   }
 
   .month-display {
+    width: 100px;
     text-align: center;
     margin: 0 44px;
 

--- a/client/src/components/TransactionForm/index.ts
+++ b/client/src/components/TransactionForm/index.ts
@@ -7,18 +7,11 @@ import trashIcon from 'public/assets/icon/trashIcon.svg';
 
 import './style.scss';
 import _ from 'src/utils/dom';
-
-interface FormType {
-  date: string;
-  category: string;
-  title: string;
-  method: string;
-  price: number;
-}
+import { RecordType } from 'src/store/transaction';
 
 interface PropsType {
   isEdit: boolean;
-  data: FormType;
+  data: RecordType;
 }
 
 interface StateType {
@@ -29,10 +22,11 @@ interface StateType {
 const INIT_FORM = {
   isEdit: false,
   data: {
+    id: '',
     date: '',
     category: '',
     title: '',
-    method: '',
+    payment: '',
     price: 0,
   },
 };
@@ -55,7 +49,7 @@ export default class TransactionFrom extends Component<StateType, PropsType> {
   setTemplate(): string {
     if (!this.state) return '';
 
-    const { date, category, title, method, price } = this.props.data;
+    const { date, category, title, payment, price } = this.props.data;
     const { isIncome, isAbleSubmit } = this.state;
 
     return `
@@ -91,7 +85,7 @@ export default class TransactionFrom extends Component<StateType, PropsType> {
       <div class="transaction__form-column transaction__method" >
         <div>결제수단</div>
         <div>
-          <div class="${method ? '' : 'empty'}">${method ? method : '선택하세요'}</div>
+          <div class="${payment ? '' : 'empty'}">${payment ? payment : '선택하세요'}</div>
           <img class="form-dropdown-btn" src=${downArrow} alt='펼쳐보기' />
         </div>
       </div>

--- a/client/src/components/TransactionHeader/index.ts
+++ b/client/src/components/TransactionHeader/index.ts
@@ -1,8 +1,12 @@
 import Component from 'src/lib/component';
+import { getState, setState } from 'src/lib/observer';
+
+import { transactionPriceType, transactionPriceTypeState } from 'src/store/transaction';
 
 import activePicker from 'public/assets/icon/activePicker.svg';
 import inActivePicker from 'public/assets/icon/inActivePicker.svg';
 
+import _ from 'src/utils/dom';
 import { getNumberWithComma } from 'src/utils/price';
 
 import './style.scss';
@@ -16,7 +20,20 @@ interface TransactionInfoType {
 }
 
 export default class TransactionHeader extends Component {
+  //TODO: 리팩토링 - setState타입을 설정해주기
+  setType: (newState: any) => void;
+  constructor() {
+    super();
+    this.keys = [transactionPriceTypeState];
+    this.setType = setState(transactionPriceTypeState);
+    this.subscribe();
+  }
+  addEvent(): void {
+    _.onEvent(this, 'click', this.handleClick.bind(this));
+  }
   setTemplate(): string {
+    const { isIncome, isExpenditure } = getState(transactionPriceTypeState);
+
     const {
       total,
       price: { income, expenditure },
@@ -24,20 +41,42 @@ export default class TransactionHeader extends Component {
     return `
       <h2 class="transaction__total" >전체 내역 ${total}건</h2>
       <div class="transaciton__price-info" >
-        <div>
-          <img src=${activePicker} alt="수입 버튼" />
+        <div id="transaction__income-btn">
+          <img src=${isIncome ? activePicker : inActivePicker} alt="수입 버튼" />
           <div>수입 ${getNumberWithComma(income)}</div>
         </div>
-        <div>
-          <img src=${inActivePicker} alt="수입 버튼" />
+        <div id="transaction__expenditure-btn">
+          <img src=${isExpenditure ? activePicker : inActivePicker} alt="수입 버튼" />
           <div>지출 ${getNumberWithComma(expenditure)}</div>
         </div>
       </div>  
     `;
   }
 
+  handleClick(e: Event) {
+    const target = e.target as HTMLElement;
+
+    if (this.isIncomeBtn(target)) {
+      this.setType((type: transactionPriceType) => ({ ...type, isIncome: !type.isIncome }));
+    }
+
+    if (this.isExpenditureBtn(target)) {
+      this.setType((type: transactionPriceType) => ({
+        ...type,
+        isExpenditure: !type.isExpenditure,
+      }));
+    }
+  }
+
   getTransactionInfo(): TransactionInfoType {
     return sampleData;
+  }
+
+  isIncomeBtn(target: HTMLElement): boolean {
+    return !!target.closest('#transaction__income-btn');
+  }
+  isExpenditureBtn(target: HTMLElement): boolean {
+    return !!target.closest('#transaction__expenditure-btn');
   }
 }
 

--- a/client/src/components/TransactionHeader/index.ts
+++ b/client/src/components/TransactionHeader/index.ts
@@ -1,13 +1,18 @@
 import Component from 'src/lib/component';
 import { getState, setState } from 'src/lib/observer';
 
-import { transactionPriceType, transactionPriceTypeState, dateState } from 'src/store/transaction';
+import {
+  transactionPriceType,
+  transactionPriceTypeState,
+  transactionState,
+} from 'src/store/transaction';
 
 import activePicker from 'public/assets/icon/activePicker.svg';
 import inActivePicker from 'public/assets/icon/inActivePicker.svg';
 
 import _ from 'src/utils/dom';
 import { getNumberWithComma } from 'src/utils/price';
+import { getTransaction } from 'src/api/transaction';
 
 import './style.scss';
 
@@ -24,30 +29,28 @@ export default class TransactionHeader extends Component {
   setType: (newState: (arg: transactionPriceType) => transactionPriceType) => void;
   constructor() {
     super();
-    this.keys = [transactionPriceTypeState, dateState];
+    this.keys = [transactionPriceTypeState, transactionState];
     this.setType = setState(transactionPriceTypeState);
     this.subscribe();
+    getTransaction();
   }
   addEvent(): void {
     _.onEvent(this, 'click', this.handleClick.bind(this));
   }
   setTemplate(): string {
     const { isIncome, isExpenditure } = getState(transactionPriceTypeState);
+    const { totalCount, totalIncome, totalExpenditure } = getState(transactionState);
 
-    const {
-      total,
-      price: { income, expenditure },
-    } = this.getTransactionInfo();
     return `
-      <h2 class="transaction__total" >전체 내역 ${total}건</h2>
+      <h2 class="transaction__total" >전체 내역 ${totalCount}건</h2>
       <div class="transaciton__price-info" >
         <div id="transaction__income-btn">
           <img src=${isIncome ? activePicker : inActivePicker} alt="수입 버튼" />
-          <div>수입 ${getNumberWithComma(income)}</div>
+          <div>수입 ${getNumberWithComma(totalIncome)}</div>
         </div>
         <div id="transaction__expenditure-btn">
           <img src=${isExpenditure ? activePicker : inActivePicker} alt="수입 버튼" />
-          <div>지출 ${getNumberWithComma(expenditure)}</div>
+          <div>지출 ${getNumberWithComma(totalExpenditure)}</div>
         </div>
       </div>  
     `;
@@ -58,6 +61,7 @@ export default class TransactionHeader extends Component {
 
     if (this.isIncomeBtn(target)) {
       this.setType((type) => ({ ...type, isIncome: !type.isIncome }));
+      getTransaction();
     }
 
     if (this.isExpenditureBtn(target)) {
@@ -65,11 +69,8 @@ export default class TransactionHeader extends Component {
         ...type,
         isExpenditure: !type.isExpenditure,
       }));
+      getTransaction();
     }
-  }
-
-  getTransactionInfo(): TransactionInfoType {
-    return sampleData;
   }
 
   isIncomeBtn(target: HTMLElement): boolean {
@@ -81,11 +82,3 @@ export default class TransactionHeader extends Component {
 }
 
 customElements.define('transaction-header', TransactionHeader);
-
-const sampleData: TransactionInfoType = {
-  total: 13,
-  price: {
-    income: 1822480,
-    expenditure: 700000,
-  },
-};

--- a/client/src/components/TransactionHeader/index.ts
+++ b/client/src/components/TransactionHeader/index.ts
@@ -1,7 +1,7 @@
 import Component from 'src/lib/component';
 import { getState, setState } from 'src/lib/observer';
 
-import { transactionPriceType, transactionPriceTypeState } from 'src/store/transaction';
+import { transactionPriceType, transactionPriceTypeState, dateState } from 'src/store/transaction';
 
 import activePicker from 'public/assets/icon/activePicker.svg';
 import inActivePicker from 'public/assets/icon/inActivePicker.svg';
@@ -21,10 +21,10 @@ interface TransactionInfoType {
 
 export default class TransactionHeader extends Component {
   //TODO: 리팩토링 - setState타입을 설정해주기
-  setType: (newState: any) => void;
+  setType: (newState: (arg: transactionPriceType) => transactionPriceType) => void;
   constructor() {
     super();
-    this.keys = [transactionPriceTypeState];
+    this.keys = [transactionPriceTypeState, dateState];
     this.setType = setState(transactionPriceTypeState);
     this.subscribe();
   }
@@ -53,15 +53,15 @@ export default class TransactionHeader extends Component {
     `;
   }
 
-  handleClick(e: Event) {
+  handleClick(e: Event): void {
     const target = e.target as HTMLElement;
 
     if (this.isIncomeBtn(target)) {
-      this.setType((type: transactionPriceType) => ({ ...type, isIncome: !type.isIncome }));
+      this.setType((type) => ({ ...type, isIncome: !type.isIncome }));
     }
 
     if (this.isExpenditureBtn(target)) {
-      this.setType((type: transactionPriceType) => ({
+      this.setType((type) => ({
         ...type,
         isExpenditure: !type.isExpenditure,
       }));

--- a/client/src/components/TransactionList/DayTransaction.ts
+++ b/client/src/components/TransactionList/DayTransaction.ts
@@ -6,14 +6,14 @@ import { getDate } from 'src/utils/date';
 import { getNumberWithComma } from 'src/utils/price';
 
 import { objType } from 'src/type/type';
-import { DayTransactionType, PaymentType } from 'src/type/transaction';
+import { DayRecordsType, RecordType } from 'src/store/transaction';
 
 type StateType = void;
 
 type ComponentType = { [key: string]: HTMLElement };
 
-export default class DayTransaction extends Component<StateType, DayTransactionType> {
-  constructor(props: DayTransactionType) {
+export default class DayTransaction extends Component<StateType, DayRecordsType> {
+  constructor(props: DayRecordsType) {
     super(props);
   }
 
@@ -44,18 +44,18 @@ export default class DayTransaction extends Component<StateType, DayTransactionT
   setComponents(): ComponentType | objType {
     if (!this.props) return {};
 
-    const { date, transaction } = this.props;
+    const { transaction } = this.props;
 
     const components: ComponentType = {};
     transaction.forEach((record, idx) => {
       const key = `transaction-record-${idx}`;
-      components[key] = new TransactionRecord({ date, ...record });
+      components[key] = new TransactionRecord({ ...record });
     });
 
     return components;
   }
 
-  getTotalPrice(transaction: Array<PaymentType>): number {
+  getTotalPrice(transaction: Array<RecordType>): number {
     const totalPrice = transaction.reduce((acc, record) => (acc += record.price), 0);
     return totalPrice;
   }

--- a/client/src/components/TransactionList/TransactionRecord.ts
+++ b/client/src/components/TransactionList/TransactionRecord.ts
@@ -1,6 +1,6 @@
 import Component from 'src/lib/component';
 import { ComponentType, objType } from 'src/lib/component/type';
-import { PaymentType } from 'src/type/transaction';
+import { RecordType } from 'src/store/transaction';
 import CategoryBadge from '../CategoryBadge';
 import TransactionFrom from '../TransactionForm';
 
@@ -8,12 +8,8 @@ type StateType = {
   isEdit: boolean;
 };
 
-interface PropsType extends PaymentType {
-  date: string;
-}
-
-export default class TransactionRecord extends Component<StateType, PropsType> {
-  constructor(props: PropsType) {
+export default class TransactionRecord extends Component<StateType, RecordType> {
+  constructor(props: RecordType) {
     super(props);
   }
   initState(): StateType {
@@ -23,7 +19,7 @@ export default class TransactionRecord extends Component<StateType, PropsType> {
   setTemplate(): string {
     if (!this.state) return '';
 
-    const { title, method, price } = this.props;
+    const { title, payment, price } = this.props;
     const { isEdit } = this.state;
     return `
       <div class="transaction__record-container">
@@ -32,7 +28,7 @@ export default class TransactionRecord extends Component<StateType, PropsType> {
             <div id="category-badge"></div>
             <div class="transaction__record-title">${title}</div>
           </div>
-          <div class="transaction__record-method">${method}</div>
+          <div class="transaction__record-method">${payment}</div>
           <div class="transaction__record-price">${price}</div>
         </div>
         ${

--- a/client/src/components/TransactionList/index.ts
+++ b/client/src/components/TransactionList/index.ts
@@ -6,15 +6,21 @@ import { objType } from 'src/type/type';
 import { TransactionType } from 'src/type/transaction';
 
 import './style.scss';
+import { DayRecordsType, transactionState } from 'src/store/transaction';
+import { getState } from 'src/lib/observer';
 
 export default class TransationList extends Component {
   constructor() {
     super();
+    this.keys = [transactionState];
+    this.subscribe();
   }
 
   //TODO 진짜데이터 props로 받아와서 처리
   setTemplate(): string {
-    const template = sampleData.reduce((acc, cur, idx) => {
+    const { transaction } = getState(transactionState);
+
+    const template = transaction.reduce((acc: string, cur: DayRecordsType, idx: number) => {
       return acc + `<div id='transaction-${idx}'></div>`;
     }, '');
     return template;
@@ -22,50 +28,15 @@ export default class TransationList extends Component {
 
   //TODO 진짜데이터 props로 받아와서 처리
   setComponents(): { [key: string]: HTMLElement } {
+    const { transaction } = getState(transactionState);
+    console.log(transaction);
     const components: objType = {};
-    sampleData.forEach((data, idx) => {
+    transaction.forEach((data: DayRecordsType, idx: number) => {
       const key = `transaction-${idx}`;
-      components[key] = new DayTransaction({ ...data });
+      components[key] = new DayTransaction(data);
     });
     return components;
   }
 }
 
 customElements.define('transaction-list', TransationList);
-
-const sampleData: TransactionType = [
-  {
-    date: '2021.07.28',
-    transaction: [
-      {
-        category: 'culture',
-        title: '스트리밍서비스 정기 결제',
-        method: '현대카드',
-        price: -10900,
-      },
-      {
-        category: 'transport',
-        title: '후불 교통비 결제',
-        method: '현대카드',
-        price: -45340,
-      },
-    ],
-  },
-  {
-    date: '2021.07.27',
-    transaction: [
-      {
-        category: 'etc',
-        title: '온라인 세미나 신청',
-        method: '현대카드',
-        price: -10000,
-      },
-      {
-        category: 'salary',
-        title: '7월 급여',
-        method: '현금',
-        price: 1000000,
-      },
-    ],
-  },
-];

--- a/client/src/store/transaction.ts
+++ b/client/src/store/transaction.ts
@@ -19,7 +19,7 @@ export const transactionPriceTypeState = initState({
   defaultValue: { isIncome: true, isExpenditure: true },
 });
 
-interface RecordType {
+export interface RecordType {
   id: string;
   date: string;
   category: string;
@@ -27,7 +27,7 @@ interface RecordType {
   payment: string;
   price: number;
 }
-interface DayRecordsType {
+export interface DayRecordsType {
   date: string;
   transaction: Array<RecordType>;
 }

--- a/client/src/store/transaction.ts
+++ b/client/src/store/transaction.ts
@@ -5,7 +5,11 @@ export const dateState = initState({
   defaultValue: { year: new Date().getFullYear(), month: new Date().getMonth() + 1 },
 });
 
-export const transactionTypeState = initState({
+export interface transactionPriceType {
+  isIncome: boolean;
+  isExpenditure: boolean;
+}
+export const transactionPriceTypeState = initState({
   key: 'transactionTypeState-isIncome/isExpenditure',
   defaultValue: { isIncome: true, isExpenditure: true },
 });

--- a/client/src/store/transaction.ts
+++ b/client/src/store/transaction.ts
@@ -18,3 +18,33 @@ export const transactionPriceTypeState = initState({
   key: 'transactionTypeState-isIncome/isExpenditure',
   defaultValue: { isIncome: true, isExpenditure: true },
 });
+
+interface RecordType {
+  id: string;
+  date: string;
+  category: string;
+  title: string;
+  payment: string;
+  price: number;
+}
+interface DayRecordsType {
+  date: string;
+  transaction: Array<RecordType>;
+}
+
+export interface transactionType {
+  totalCount: number;
+  totalIncome: number;
+  totalExpenditure: number;
+  transaction: Array<DayRecordsType>;
+}
+
+export const transactionState = initState({
+  key: 'transactionState',
+  defaultValue: {
+    totalCount: 0,
+    totalIncome: 0,
+    totalExpenditure: 0,
+    transaction: [],
+  },
+});

--- a/client/src/store/transaction.ts
+++ b/client/src/store/transaction.ts
@@ -1,5 +1,10 @@
 import { initState } from 'src/lib/observer';
 
+export interface DateType {
+  year: number;
+  month: number;
+}
+
 export const dateState = initState({
   key: 'dateState',
   defaultValue: { year: new Date().getFullYear(), month: new Date().getMonth() + 1 },

--- a/client/src/store/transaction.ts
+++ b/client/src/store/transaction.ts
@@ -4,3 +4,8 @@ export const dateState = initState({
   key: 'dateState',
   defaultValue: { year: new Date().getFullYear(), month: new Date().getMonth() + 1 },
 });
+
+export const transactionTypeState = initState({
+  key: 'transactionTypeState-isIncome/isExpenditure',
+  defaultValue: { isIncome: true, isExpenditure: true },
+});

--- a/client/src/utils/date.ts
+++ b/client/src/utils/date.ts
@@ -14,3 +14,17 @@ export const getDate = (date: string): DateType => {
     day: DAYS[dateObj.getDay()],
   };
 };
+
+interface YearMonthType {
+  year: number;
+  month: number;
+}
+
+export const getNextMonth = ({ year, month }: YearMonthType): YearMonthType => {
+  if (month === 12) return { year: year + 1, month: 1 };
+  return { year, month: month + 1 };
+};
+export const getPrevMonth = ({ year, month }: YearMonthType): YearMonthType => {
+  if (month === 1) return { year: year - 1, month: 12 };
+  return { year, month: month - 1 };
+};

--- a/client/webpack.dev.js
+++ b/client/webpack.dev.js
@@ -11,6 +11,7 @@ export default merge(common, {
     port: PORT,
     proxy: {
       '/': 'http://localhost:3000',
+      '/': 'http://localhost:4000',
     },
   },
 });


### PR DESCRIPTION
#28
 
## 개요

메인화면 거래내역 패치 후 렌더링

## 변경사항

- 헤더 날짜 변경
- transaction 수입/지출 토글
- dev-server proxy 추가
- 거래내역 조회 api 반환값 수정
- 메인페이지 패치 후 렌더링 및 컴포넌트들 맞게 타입수정 

## 참고사항

## 추가 구현 필요사항

## 스크린샷
