### PR TITLE
[FE] 메인화면, 달력 데이터 받아와서 렌더링

### DIFF
--- a/api/configs/cors.ts
+++ b/api/configs/cors.ts
@@ -1,5 +1,5 @@
 const corsOptions = {
-  origin: 'http://localhost:3000', // 접근 권한을 부여하는 도메인 (Web Server)
+  origin: 'http://localhost:8000', // 접근 권한을 부여하는 도메인 (Web Server)
   credentials: true, // 응답 헤더에 Access-Control-Allow-Credentials 추가
   optionsSuccessStatus: 200, // 응답 상태 200으로 설정
 };

--- a/api/services/transaction.ts
+++ b/api/services/transaction.ts
@@ -7,7 +7,6 @@ import {
   getTransactionParamType,
   TransactionRecordType,
   DayTransactionType,
-  TransactionDataType,
   CalendarStatisticsType,
 } from 'types/transaction';
 
@@ -341,6 +340,7 @@ async function getCalendarStatistics(
   const result: CalendarStatisticsType = {
     totalIncome: 0,
     totalExpenditure: 0,
+    totalPrice: 0,
     statistics: {},
   };
 
@@ -378,6 +378,8 @@ async function getCalendarStatistics(
       }
     }
   });
+
+  result.totalPrice = result.totalIncome + result.totalExpenditure;
 
   return result;
 }

--- a/api/types/transaction.ts
+++ b/api/types/transaction.ts
@@ -38,6 +38,7 @@ export interface TransactionDataType {
 export interface CalendarStatisticsType {
   totalIncome: number;
   totalExpenditure: number;
+  totalPrice: number;
   statistics: {
     [key: number]: {
       income: number;

--- a/client/src/api/calendar.ts
+++ b/client/src/api/calendar.ts
@@ -1,0 +1,13 @@
+import { STATISTICS_URL } from './../configs/urls';
+import { getState } from 'src/lib/observer';
+import { dateState } from 'src/store/transaction';
+import fetchWrapper from 'src/utils/fetchWrapper';
+
+export const getCalendarStatistics = async (): Promise<{ success: boolean; response: any }> => {
+  const { year, month } = getState(dateState);
+
+  const query = `type=calendar&year=${year}&month=${month}`;
+
+  const data = await fetchWrapper(`${STATISTICS_URL}?${query}`, 'GET');
+  return data;
+};

--- a/client/src/api/transaction.ts
+++ b/client/src/api/transaction.ts
@@ -1,21 +1,15 @@
-import { getState, setState } from 'src/lib/observer';
-import { dateState, transactionPriceTypeState, transactionState } from 'src/store/transaction';
+import { TRANSACTION_URL } from './../configs/urls';
+import { getState } from 'src/lib/observer';
+import { dateState, transactionPriceTypeState } from 'src/store/transaction';
+import fetchWrapper from 'src/utils/fetchWrapper';
 
-export const getTransaction = async (): Promise<void> => {
+export const getTransaction = async (): Promise<{ success: boolean; response: any }> => {
   const { year, month } = getState(dateState);
   const { isIncome, isExpenditure } = getState(transactionPriceTypeState);
 
-  const token = localStorage.getItem('token');
   const query = `year=${year}&month=${month}&isIncome=${isIncome}&isExpenditure=${isExpenditure}`;
 
-  const res = await fetch(`/transaction?${query}`, {
-    headers: {
-      'Content-Type': 'application/json',
-      Authorization: `Bearer ${token}`,
-    },
-  });
-  const { data } = await res.json();
-  setState(transactionState)(data);
+  const data = await fetchWrapper(`${TRANSACTION_URL}?${query}`, 'GET');
   return data;
 };
 

--- a/client/src/components/Calendar/CalendarDate.ts
+++ b/client/src/components/Calendar/CalendarDate.ts
@@ -1,39 +1,32 @@
-import { dateState } from './../../store/transaction';
 import Component from 'src/lib/component';
 import { getState } from 'src/lib/observer';
-import { getMonthData } from 'src/utils/calendar';
+
+import { getMonthData, isToday } from 'src/utils/calendar';
 import { getNumberWithComma } from 'src/utils/price';
 
+import { dateState } from 'src/store/transaction';
+import { calendarDataState } from 'src/store/calendar';
+
 interface TotalPriceType {
-  income?: number;
-  expenditure?: number;
+  income: number;
+  expenditure: number;
   total: number;
-}
-
-interface calendarPriceInfoType {
-  [key: string]: TotalPriceType;
-}
-
-interface DateType {
-  year: number;
-  month: number;
-  date: number;
 }
 
 export default class CalendarDate extends Component {
   constructor() {
     super();
-    this.keys = [dateState];
+    this.keys = [dateState, calendarDataState];
     this.subscribe();
   }
   setTemplate(): string {
     const date = getState(dateState);
     const monthArr = getMonthData(date);
-    const priceInfo = this.getPriceInfo();
+    const { statistics: priceInfo } = getState(calendarDataState);
 
     const monthTemplate: string = monthArr.reduce((acc, weekArr) => {
       const weekTemplate = weekArr.reduce((acc, day) => {
-        const tdClass = this.isToday({ year: date.year, month: date.month, date: day ?? 0 })
+        const tdClass = isToday({ year: date.year, month: date.month, date: day ?? 0 })
           ? 'today-date'
           : '';
 
@@ -58,7 +51,7 @@ export default class CalendarDate extends Component {
     `;
   }
 
-  priceTemplate(priceInfo: TotalPriceType | void): string {
+  priceTemplate(priceInfo: TotalPriceType): string {
     if (!priceInfo) return `<div class='calendar__price-info'></div>`;
 
     const { income, expenditure, total } = priceInfo;
@@ -75,43 +68,6 @@ export default class CalendarDate extends Component {
       </div>
     `;
   }
-  getPriceInfo(): calendarPriceInfoType {
-    //fetch 작업
-    return sample;
-  }
-
-  isToday({ year, month, date }: DateType): boolean {
-    const dateObj = new Date();
-
-    const todayYear = dateObj.getFullYear();
-    const todayMonth = dateObj.getMonth() + 1;
-    const todayDate = dateObj.getDate();
-
-    if (todayYear === year && todayMonth === month && todayDate === date) return true;
-
-    return false;
-  }
 }
 
 customElements.define('calendar-date', CalendarDate);
-
-const sample: calendarPriceInfoType = {
-  2: {
-    expenditure: -5400,
-    total: -5400,
-  },
-  4: {
-    expenditure: -132000,
-    total: -132000,
-  },
-  9: {
-    income: 1000000,
-    expenditure: -10000,
-    total: 990000,
-  },
-  18: {
-    income: 50000,
-    expenditure: -10000,
-    total: 40000,
-  },
-};

--- a/client/src/components/Calendar/TotalPriceInfo.ts
+++ b/client/src/components/Calendar/TotalPriceInfo.ts
@@ -1,15 +1,17 @@
 import Component from 'src/lib/component';
-import { getNumberWithComma } from 'src/utils/price';
+import { getState } from 'src/lib/observer';
 
-interface TotalPriceInfoType {
-  totalIncome: number;
-  totalExpenditure: number;
-  totalPrice: number;
-}
+import { getNumberWithComma } from 'src/utils/price';
+import { calendarDataState } from 'src/store/calendar';
 
 export default class TotalPriceInfo extends Component {
+  constructor() {
+    super();
+    this.keys = [calendarDataState];
+    this.subscribe();
+  }
   setTemplate(): string {
-    const { totalIncome, totalExpenditure, totalPrice } = this.getTotalPriceInfo();
+    const { totalIncome, totalExpenditure, totalPrice } = getState(calendarDataState);
 
     return `
       <div>
@@ -19,17 +21,6 @@ export default class TotalPriceInfo extends Component {
       <div>총계 ${getNumberWithComma(totalPrice)}</div>
     `;
   }
-
-  getTotalPriceInfo(): TotalPriceInfoType {
-    //fetch
-    return sample;
-  }
 }
 
 customElements.define('total-price-info', TotalPriceInfo);
-
-const sample: TotalPriceInfoType = {
-  totalIncome: 1000000,
-  totalExpenditure: -157400,
-  totalPrice: 864200,
-};

--- a/client/src/components/Header/index.ts
+++ b/client/src/components/Header/index.ts
@@ -8,13 +8,13 @@ import leftArrow from 'public/assets/icon/leftArrow.svg';
 import rightArrow from 'public/assets/icon/rightArrow.svg';
 
 import _ from 'src/utils/dom';
+import { setTransactionData } from 'src/utils/transaction';
 import { getNextMonth, getPrevMonth } from 'src/utils/date';
 import { dateState, DateType } from 'src/store/transaction';
 
 import { router } from '../../../index';
 
 import './style.scss';
-import { getTransaction } from 'src/api/transaction';
 
 export default class Header extends Component {
   setDate: (newState: DateType) => void;
@@ -74,11 +74,11 @@ export default class Header extends Component {
 
     if (this.isLeftArrow(target)) {
       this.setDate(getPrevMonth(currentDate));
-      getTransaction();
+      setTransactionData();
     }
     if (this.isRightArrow(target)) {
       this.setDate(getNextMonth(currentDate));
-      getTransaction();
+      setTransactionData();
     }
 
     const button: HTMLButtonElement | null = target.closest('.navigator>button');

--- a/client/src/components/Header/index.ts
+++ b/client/src/components/Header/index.ts
@@ -8,7 +8,7 @@ import leftArrow from 'public/assets/icon/leftArrow.svg';
 import rightArrow from 'public/assets/icon/rightArrow.svg';
 
 import _ from 'src/utils/dom';
-import { setTransactionData } from 'src/utils/transaction';
+import { setTransactionData } from 'src/utils/dataSetting';
 import { getNextMonth, getPrevMonth } from 'src/utils/date';
 import { dateState, DateType } from 'src/store/transaction';
 

--- a/client/src/components/TransactionHeader/index.ts
+++ b/client/src/components/TransactionHeader/index.ts
@@ -11,7 +11,7 @@ import activePicker from 'public/assets/icon/activePicker.svg';
 import inActivePicker from 'public/assets/icon/inActivePicker.svg';
 
 import _ from 'src/utils/dom';
-import { setTransactionData } from 'src/utils/transaction';
+import { setTransactionData } from 'src/utils/dataSetting';
 import { getNumberWithComma } from 'src/utils/price';
 
 import './style.scss';

--- a/client/src/components/TransactionHeader/index.ts
+++ b/client/src/components/TransactionHeader/index.ts
@@ -11,8 +11,8 @@ import activePicker from 'public/assets/icon/activePicker.svg';
 import inActivePicker from 'public/assets/icon/inActivePicker.svg';
 
 import _ from 'src/utils/dom';
+import { setTransactionData } from 'src/utils/transaction';
 import { getNumberWithComma } from 'src/utils/price';
-import { getTransaction } from 'src/api/transaction';
 
 import './style.scss';
 
@@ -32,7 +32,6 @@ export default class TransactionHeader extends Component {
     this.keys = [transactionPriceTypeState, transactionState];
     this.setType = setState(transactionPriceTypeState);
     this.subscribe();
-    getTransaction();
   }
   addEvent(): void {
     _.onEvent(this, 'click', this.handleClick.bind(this));
@@ -61,7 +60,7 @@ export default class TransactionHeader extends Component {
 
     if (this.isIncomeBtn(target)) {
       this.setType((type) => ({ ...type, isIncome: !type.isIncome }));
-      getTransaction();
+      setTransactionData();
     }
 
     if (this.isExpenditureBtn(target)) {
@@ -69,7 +68,7 @@ export default class TransactionHeader extends Component {
         ...type,
         isExpenditure: !type.isExpenditure,
       }));
-      getTransaction();
+      setTransactionData();
     }
   }
 

--- a/client/src/components/TransactionList/index.ts
+++ b/client/src/components/TransactionList/index.ts
@@ -3,7 +3,6 @@ import Component from 'src/lib/component';
 import DayTransaction from './DayTransaction';
 
 import { objType } from 'src/type/type';
-import { TransactionType } from 'src/type/transaction';
 
 import './style.scss';
 import { DayRecordsType, transactionState } from 'src/store/transaction';
@@ -29,7 +28,7 @@ export default class TransationList extends Component {
   //TODO 진짜데이터 props로 받아와서 처리
   setComponents(): { [key: string]: HTMLElement } {
     const { transaction } = getState(transactionState);
-    console.log(transaction);
+
     const components: objType = {};
     transaction.forEach((data: DayRecordsType, idx: number) => {
       const key = `transaction-${idx}`;

--- a/client/src/configs/urls.ts
+++ b/client/src/configs/urls.ts
@@ -3,3 +3,5 @@ const BASE_URL = 'http://localhost:4000';
 export const SIGNIN_URL = `${BASE_URL}/auth/signin`;
 export const SIGNUP_URL = `${BASE_URL}/auth/signup`;
 export const SIGNOUT_URL = `${BASE_URL}/auth/signout`;
+
+export const TRANSACTION_URL = `${BASE_URL}/transaction`;

--- a/client/src/configs/urls.ts
+++ b/client/src/configs/urls.ts
@@ -5,3 +5,5 @@ export const SIGNUP_URL = `${BASE_URL}/auth/signup`;
 export const SIGNOUT_URL = `${BASE_URL}/auth/signout`;
 
 export const TRANSACTION_URL = `${BASE_URL}/transaction`;
+
+export const STATISTICS_URL = `${TRANSACTION_URL}/statistics`;

--- a/client/src/store/calendar.ts
+++ b/client/src/store/calendar.ts
@@ -1,0 +1,24 @@
+import { initState } from 'src/lib/observer';
+
+export interface CalendarStatisticsType {
+  totalIncome: number;
+  totalExpenditure: number;
+  totalPrice: number;
+  statistics: {
+    [key: number]: {
+      income: number;
+      expenditure: number;
+      total: number;
+    };
+  };
+}
+
+export const calendarDataState = initState({
+  key: 'calendar date state',
+  defaultValue: {
+    totalIncome: 0,
+    totalExpenditure: 0,
+    totalPrice: 0,
+    statistics: {},
+  },
+});

--- a/client/src/utils/calendar.ts
+++ b/client/src/utils/calendar.ts
@@ -2,6 +2,11 @@ export interface calendarDateType {
   year: number;
   month: number;
 }
+interface DateType {
+  year: number;
+  month: number;
+  date: number;
+}
 
 export const getMonthData = ({ year, month }: calendarDateType): (number | null)[][] => {
   const monthArr: (number | null)[][] = [];
@@ -25,4 +30,16 @@ export const getMonthData = ({ year, month }: calendarDateType): (number | null)
   monthArr.push(weekArr); //마지막 weekArr도 추가
 
   return monthArr;
+};
+
+export const isToday = ({ year, month, date }: DateType): boolean => {
+  const dateObj = new Date();
+
+  const todayYear = dateObj.getFullYear();
+  const todayMonth = dateObj.getMonth() + 1;
+  const todayDate = dateObj.getDate();
+
+  if (todayYear === year && todayMonth === month && todayDate === date) return true;
+
+  return false;
 };

--- a/client/src/utils/dataSetting.ts
+++ b/client/src/utils/dataSetting.ts
@@ -1,7 +1,11 @@
 import { getState, setState } from 'src/lib/observer';
+
 import { getTransaction } from 'src/api/transaction';
-import { transactionState } from 'src/store/transaction';
+import { getCalendarStatistics } from 'src/api/calendar';
+
 import { pageState } from 'src/store/page';
+import { transactionState } from 'src/store/transaction';
+import { calendarDataState } from 'src/store/calendar';
 
 //util안에 있을 애는 아닌 것 같은데 위치를 못잡겠음
 
@@ -11,11 +15,13 @@ export async function setTransactionData(): Promise<any> {
   const pageName = Page.name;
 
   if (pageName === 'MainPage') {
-    const data = await getTransaction();
+    const { success, response } = await getTransaction();
     //TODO에러처리
-    if (data.success) setState(transactionState)(data.response.data);
+    if (success) setState(transactionState)(response.data);
   }
   if (pageName === 'CalendarPage') {
+    const { success, response } = await getCalendarStatistics();
+    if (success) setState(calendarDataState)(response.result);
   }
   if (pageName === 'ChartPage') {
   }

--- a/client/src/utils/fetchWrapper.ts
+++ b/client/src/utils/fetchWrapper.ts
@@ -4,7 +4,7 @@ type ObjectType = {
   [key in string]: any;
 };
 
-async function fetchWrapper(url: string, method: MethodType, body: ObjectType): Promise<any> {
+async function fetchWrapper(url: string, method: MethodType, body?: ObjectType): Promise<any> {
   try {
     const token = window.localStorage.getItem('_at') || '';
 

--- a/client/src/utils/fetchWrapper.ts
+++ b/client/src/utils/fetchWrapper.ts
@@ -24,7 +24,7 @@ async function fetchWrapper(url: string, method: MethodType, body?: ObjectType):
 
     const response = await res.json();
 
-    return { success: true, ...response };
+    return { success: true, response };
   } catch (err) {
     console.log(err);
   }

--- a/client/src/utils/transaction.ts
+++ b/client/src/utils/transaction.ts
@@ -1,0 +1,22 @@
+import { getState, setState } from 'src/lib/observer';
+import { getTransaction } from 'src/api/transaction';
+import { transactionState } from 'src/store/transaction';
+import { pageState } from 'src/store/page';
+
+//util안에 있을 애는 아닌 것 같은데 위치를 못잡겠음
+
+//TODO 함수 위치 변경
+export async function setTransactionData(): Promise<any> {
+  const { Page } = getState(pageState);
+  const pageName = Page.name;
+
+  if (pageName === 'MainPage') {
+    const data = await getTransaction();
+    //TODO에러처리
+    if (data.success) setState(transactionState)(data.response.data);
+  }
+  if (pageName === 'CalendarPage') {
+  }
+  if (pageName === 'ChartPage') {
+  }
+}

--- a/client/webpack.dev.js
+++ b/client/webpack.dev.js
@@ -11,7 +11,6 @@ export default merge(common, {
     port: PORT,
     proxy: {
       '/': 'http://localhost:3000',
-      '/': 'http://localhost:4000',
     },
   },
 });


### PR DESCRIPTION
#33 #28  #83 

## 개요

메인,달력 페이지 - 데이터 get 후 렌더링

## 변경사항

- 달력 페이지 fetch 후 렌러딩
- 달력 통계 조회 반환값 수정 (전체 가격 합산도 반환)
- fetchWrapper 사용으로 변경
- isToday 유틸함수로 분리
- 초기로딩 시 전역데이터 setting (나중에 로그인 체크 부분과 합치면 될 듯)

## 참고사항

## 추가 구현 필요사항

## 스크린샷
