### PR TITLE
refactor: 토큰 재발행 로직 리팩토링(#24)

### DIFF
--- a/api/middlewares/validate-token.ts
+++ b/api/middlewares/validate-token.ts
@@ -7,8 +7,9 @@ import errorHandler from 'utils/error-handler';
 async function validateToken(req: Request, res: Response, next: NextFunction): Promise<void> {
   try {
     const accessToken = getAccessToken(req.headers.authorization);
+    const refreshToken = req.cookies['_rt'];
 
-    if (!accessToken) {
+    if (!accessToken || !refreshToken) {
       throw errorGenerator({
         message: 'No token',
         code: 'req/no-token',
@@ -40,7 +41,7 @@ async function validateToken(req: Request, res: Response, next: NextFunction): P
     });
 
     if (isTokenExpired) {
-      res.redirect(303, '/auth');
+      res.redirect(303, '/auth?redirect=true');
       return;
     }
 

--- a/api/routes/payment/index.ts
+++ b/api/routes/payment/index.ts
@@ -2,6 +2,8 @@ import express from 'express';
 
 import paymentService from 'services/payment';
 
+import validateToken from 'middlewares/validate-token';
+
 import { decodeToken, getAccessToken } from 'utils/jwt';
 import errorHandler from 'utils/error-handler';
 import errorGenerator from 'utils/error-generator';
@@ -16,7 +18,7 @@ const router = express.Router();
  * post: 결제수단 추가
  */
 
-router.get('/', async (req, res) => {
+router.get('/', validateToken, async (req, res) => {
   try {
     const accessToken = getAccessToken(req.headers.authorization);
     const { uid: userId } = decodeToken('access', accessToken);
@@ -30,7 +32,7 @@ router.get('/', async (req, res) => {
   }
 });
 
-router.delete('/', async (req, res) => {
+router.delete('/', validateToken, async (req, res) => {
   try {
     const accessToken = getAccessToken(req.headers.authorization);
     const { uid: userId } = decodeToken('access', accessToken);
@@ -53,7 +55,7 @@ router.delete('/', async (req, res) => {
   }
 });
 
-router.post('/', async (req, res) => {
+router.post('/', validateToken, async (req, res) => {
   try {
     const accessToken = getAccessToken(req.headers.authorization);
     const { uid: userId } = decodeToken('access', accessToken);

--- a/api/routes/transaction/index.ts
+++ b/api/routes/transaction/index.ts
@@ -25,7 +25,7 @@ router.use('/statistics', statistics);
  * post: 결제내역 추가
  */
 
-router.get('/', async (req, res) => {
+router.get('/', validateToken, async (req, res) => {
   try {
     const accessToken = getAccessToken(req.headers.authorization);
     const { uid: userId } = decodeToken('access', accessToken);
@@ -55,7 +55,7 @@ router.get('/', async (req, res) => {
   }
 });
 
-router.delete('/:id', async (req, res) => {
+router.delete('/:id', validateToken, async (req, res) => {
   try {
     const accessToken = getAccessToken(req.headers.authorization);
     const { uid: userId } = decodeToken('access', accessToken);
@@ -72,7 +72,7 @@ router.delete('/:id', async (req, res) => {
   }
 });
 
-router.put('/:id', async (req, res) => {
+router.put('/:id', validateToken, async (req, res) => {
   try {
     const accessToken = getAccessToken(req.headers.authorization);
     const { uid: userId } = decodeToken('access', accessToken);
@@ -98,7 +98,7 @@ router.put('/:id', async (req, res) => {
   }
 });
 
-router.post('/', async (req, res) => {
+router.post('/', validateToken, async (req, res) => {
   try {
     const accessToken = getAccessToken(req.headers.authorization);
     const { uid: userId } = decodeToken('access', accessToken);

--- a/api/routes/transaction/statistics/index.ts
+++ b/api/routes/transaction/statistics/index.ts
@@ -2,6 +2,8 @@ import express from 'express';
 
 import transactionService from 'services/transaction-statistics';
 
+import validateToken from 'middlewares/validate-token';
+
 import { decodeToken, getAccessToken } from 'utils/jwt';
 import errorGenerator from 'utils/error-generator';
 import errorHandler from 'utils/error-handler';
@@ -24,7 +26,7 @@ const router = express.Router();
  *     - type: calendar  : 달력 월별 통계 데이터 조회
  */
 
-router.get('/', async (req, res) => {
+router.get('/', validateToken, async (req, res) => {
   try {
     const { type, year, month, category } = req.query;
 

--- a/api/services/auth.ts
+++ b/api/services/auth.ts
@@ -1,8 +1,6 @@
-import { VerifyErrors } from 'jsonwebtoken';
-
 import { db } from 'models/db';
 
-import { createToken, verifyToken } from 'utils/jwt';
+import { createToken } from 'utils/jwt';
 import errorGenerator from 'utils/error-generator';
 import { hashPassword, checkPassword } from 'utils/encryption';
 
@@ -36,43 +34,6 @@ async function signUp(email: string, password: string): Promise<TokenType> {
   const refreshToken = createToken('refresh', { uid });
 
   return { accessToken, refreshToken };
-}
-
-async function verifyAuth(token: string): Promise<void> {
-  return new Promise((resolve, reject) => {
-    verifyToken('access', token, (err: VerifyErrors | null) => {
-      if (!err) {
-        resolve();
-        return;
-      }
-
-      switch (err.name) {
-        case 'ToeknExpiredError':
-          reject(
-            errorGenerator({
-              message: err.message,
-              code: 'auth/token-expired',
-            }),
-          );
-          break;
-        case 'JsonWebTokenError':
-          reject(
-            errorGenerator({
-              message: err.message,
-              code: 'auth/invalid-token',
-            }),
-          );
-          break;
-        default:
-          reject(
-            errorGenerator({
-              message: err.message,
-              code: 'auth/invalid-token',
-            }),
-          );
-      }
-    });
-  });
 }
 
 async function signIn(email: string, password: string): Promise<TokenType> {
@@ -112,5 +73,4 @@ async function signIn(email: string, password: string): Promise<TokenType> {
 export default {
   signIn,
   signUp,
-  verifyAuth,
 };

--- a/api/utils/jwt.ts
+++ b/api/utils/jwt.ts
@@ -12,8 +12,8 @@ const ACCESS_TOKEN_SECRET = process.env.ACCESS_TOKEN_SECRET || '';
 const REFRESH_TOKEN_SECRET = process.env.REFRESH_TOKEN_SECRET || '';
 
 export const createToken = (type: TokenType, option: OptionType): string => {
-  const ACCESS_TOKEN_EXPIRE_DATE = Math.floor(Date.now() / 1000) + 30;
-  const REFRESH_TOKEN_EXPIRE_DATE = Math.floor(Date.now() / 1000) + 60 * 1;
+  const ACCESS_TOKEN_EXPIRE_DATE = Math.floor(Date.now() / 1000) + 60 * 30;
+  const REFRESH_TOKEN_EXPIRE_DATE = Math.floor(Date.now() / 1000) + 60 * 60 * 24 * 7;
 
   const expireDate = type === 'access' ? ACCESS_TOKEN_EXPIRE_DATE : REFRESH_TOKEN_EXPIRE_DATE;
   const secret = type === 'access' ? ACCESS_TOKEN_SECRET : REFRESH_TOKEN_SECRET;
@@ -90,4 +90,17 @@ export const getUIDFromToken = (token: string): string => {
 
   const uid = decoded?.uid;
   return uid;
+};
+
+export const checkTokenValidity = (type: TokenType, token: string): Promise<boolean> => {
+  return new Promise((resolve) => {
+    const secret = type === 'access' ? ACCESS_TOKEN_SECRET : REFRESH_TOKEN_SECRET;
+    jwt.verify(token, secret, (err: VerifyErrors | null) => {
+      if (!err) {
+        resolve(true);
+        return;
+      }
+      resolve(false);
+    });
+  });
 };

--- a/client/index.ts
+++ b/client/index.ts
@@ -28,8 +28,12 @@ subscribe(isLoggedInState, setRoute);
 
 async function init() {
   try {
-    const res = await fetchWrapper(AUTH_URL, 'HEAD');
+    const res = await fetchWrapper(AUTH_URL, 'GET');
     const setLoggedInState = setState<boolean>(isLoggedInState);
+
+    if (res.response?.newAccessToken) {
+      window.localStorage.setItem('_at', res.response.newAccessToken);
+    }
 
     if (res.success) setLoggedInState(true);
     else setLoggedInState(false);


### PR DESCRIPTION
#24 #97 

## 개요
토큰 재발행 로직 리팩토링

## 변경사항
* 모든 API에 토큰 검증 및 재발행 미들웨어 추가
* 최초 로그인 여부 확인 메소드를 `HEAD /auth` 에서 `GET /auth`로 변경
* 프론트엔드 `fetchWrapper` 수정
  * 401 에러시, 토큰 삭제 로직 추가
  * 토큰 재발행시 재요청 로직 추가

## 참고사항

## 추가 구현 필요사항
* Github OAuth

## 스크린샷
